### PR TITLE
#16 Change from inline roll button to action button

### DIFF
--- a/ui/bin/roll20.js
+++ b/ui/bin/roll20.js
@@ -1,10 +1,3 @@
-(function() {
-  /**
-   * This is a test function that has no effect.
-   * Just testing the mergeScripts.sh
-   * This is also an example of an IIFE, which allows each script to be self-contained to reduce risks of collisions between scripts.
-   */
-})();
 // eslint-disable-next-line no-unused-vars
 const prevEPRoll = function() {
   let total = 0;

--- a/ui/roll20_character_sheet_0.2.css
+++ b/ui/roll20_character_sheet_0.2.css
@@ -37,13 +37,20 @@ select {
   text-align-last: center;
 }
 
+button.actionRollButton {
+  padding: 2px 3px;
+  font-size: 1.3em;
+  margin: 0 3px;
+  border-width: 1px;
+}
+
 /* Change the character for dice roll buttons to be
    the two joined squares character and give them the blue background */
-button.btn.ui-draggable[type=roll] {
+button.btn.ui-draggable[type=roll], button.actionRollButton {
   background-image: linear-gradient(90deg, #ddf, #99f);
 }
 
-button.btn.ui-draggable[type=roll]::before {
+button.btn.ui-draggable[type=roll]::before, button.actionRollButton::before {
   font-family: sans-serif;
   content: "⧉";
 }

--- a/ui/roll20_character_sheet_0.2.html
+++ b/ui/roll20_character_sheet_0.2.html
@@ -169,10 +169,9 @@
 
     <!-- Rolling -->
     <div display="inline-block">
-      <button type="roll" value="!EPRoll"></button>
+      <button name="act_epRoll" class="actionRollButton epRoll" type="action"></button>
       &emsp;
-      <button type="roll" value="!EPRoll @{roll_modifier}">
-      </button>
+      <button name="act_epRollWithModifier" class="actionRollButton epRollWithModifier" type="action"></button>
       +
       <input name="attr_roll_modifier" class="narrowish" type="number" value="0" />
       &emsp;
@@ -1409,6 +1408,23 @@
       });
   }
   on('clicked:undotoproll', undoTopRoll);
+
+  function epRoll() {
+    setAttrs({
+      pendingchat: "!EPRoll",
+    });
+  }
+  on('clicked:epRoll', epRoll);
+
+  function epRollWithModifier() {
+    getAttrs(["roll_modifier"], (values) => {
+      const { roll_modifier } = values;
+      setAttrs({
+        pendingchat: `!EPRoll ${roll_modifier}`,
+      });
+    });
+  }
+  on('clicked:epRollWithModifier', (epRollWithModifier));
 
   var updateTopActEnables = function () {
     log("Updating top action enables");

--- a/ui/scripts/test.js
+++ b/ui/scripts/test.js
@@ -1,7 +1,0 @@
-(function() {
-  /**
-   * This is a test function that has no effect.
-   * Just testing the mergeScripts.sh
-   * This is also an example of an IIFE, which allows each script to be self-contained to reduce risks of collisions between scripts.
-   */
-})();


### PR DESCRIPTION
#16 Roll20 plain button rolls do not pick up input field changes.
Example video:

https://user-images.githubusercontent.com/5629800/205470925-f23932a8-4463-4f4d-b0c0-6a5ea08b03ef.mp4

# Fix by changing to action button.

This is an example of both buttons, side-by-side

https://user-images.githubusercontent.com/5629800/205471054-56dbad4c-96c0-43b8-889f-42646a319829.mp4

I then removed the old button in this PR.