### PR TITLE
Update roll20_character_sheet_0.2.css

### DIFF
--- a/ui/roll20_character_sheet_0.2.css
+++ b/ui/roll20_character_sheet_0.2.css
@@ -769,7 +769,7 @@ input.featCP {
   width: 65px;
 }
 
-.skillbase.skillbase.skillbase {
+.skillbase.skillbase.skillbase.skillbase {
   width: 40px;
 }
 


### PR DESCRIPTION
This line needs one more .skillbase, now that it doesn't have .charsheet any more. That way it has four terms, so it overrides the default for numeric input.