### PR TITLE
Convert innate spells to use `display: grid`

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -751,7 +751,6 @@ input.featCP {
 .skillname {
   width: 150px;
   text-align: right;
-  border-left-color: black;
 }
 
 .skillability {
@@ -845,11 +844,7 @@ input.featCP {
 .isdiscipline[value="1"] ~ .skillname {
   width: 190px;
   text-align: left;
-  border-top-color: black;
-  border-left-color: black;
   font-weight: bold;
-  /* Make the border go above other borders */
-  z-index: 1;
 }
 
 .isdiscipline[value="1"] ~ .skillability,

--- a/bin/main.css
+++ b/bin/main.css
@@ -988,9 +988,12 @@ input.featCP {
 }
 
 .sectioncontrol[value=arcane] ~ div.arcane,
-.sectioncontrol[value=divine] ~ div.divine,
-.sectioncontrol[value=innate] ~ div.innate {
+.sectioncontrol[value=divine] ~ div.divine {
   display: inline-flex;
+}
+
+.sectioncontrol[value=innate] ~ div.innate {
+  display: block;
 }
 
 .spell-tabs {
@@ -1090,6 +1093,39 @@ input.featCP {
   align-items: stretch;
   /* and make rows overlap */
   margin-top: -1px;
+}
+.spells .innate-spells-header {
+  display: grid;
+  grid-template-columns: 4fr 1fr 1fr 2fr 1fr 2fr 2fr 1fr 1fr;
+  column-gap: 2px;
+  background: #93c6f2;
+  padding: 4px;
+}
+.spells .innate-spells-header > div {
+  text-align: center;
+  margin: auto;
+  font-weight: bold;
+  width: 100%;
+}
+.spells div[data-groupname=repeating_innate] > div {
+  display: grid;
+  grid-template-columns: 4fr 1fr 1fr 2fr 1fr 2fr 2fr 1fr 1fr;
+  row-gap: 4px;
+  column-gap: 2px;
+  background: aliceblue;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+.spells div[data-groupname=repeating_innate] > div > input, .spells div[data-groupname=repeating_innate] > div input[type=number], .spells div[data-groupname=repeating_innate] > div > select {
+  width: 100%;
+  margin-left: unset;
+}
+.spells div[data-groupname=repeating_innate] > div > input[type=text] {
+  text-align: left;
+}
+.spells div[data-groupname=repeating_innate] > div .spell-row.conditional-one {
+  grid-column-start: 1;
+  grid-column-end: 10;
 }
 
 .spell-row {

--- a/bin/main.css
+++ b/bin/main.css
@@ -770,6 +770,16 @@ input.featCP {
   color: blue;
 }
 
+.skillTP-grid {
+  color: #319000;
+  font-weight: bold;
+}
+
+.skillCP-grid {
+  color: blue;
+  font-weight: bold;
+}
+
 .skillexpertise {
   width: 40px;
 }
@@ -988,10 +998,7 @@ input.featCP {
 }
 
 .sectioncontrol[value=arcane] ~ div.arcane,
-.sectioncontrol[value=divine] ~ div.divine {
-  display: inline-flex;
-}
-
+.sectioncontrol[value=divine] ~ div.divine,
 .sectioncontrol[value=innate] ~ div.innate {
   display: block;
 }
@@ -1094,14 +1101,98 @@ input.featCP {
   /* and make rows overlap */
   margin-top: -1px;
 }
-.spells .innate-spells-header {
+.spells .spells-header-grid.arcane {
   display: grid;
-  grid-template-columns: 4fr 1fr 1fr 2fr 1fr 2fr 2fr 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 4fr) minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr);
   column-gap: 2px;
   background: #93c6f2;
-  padding: 4px;
+  padding: 2px;
 }
-.spells .innate-spells-header > div {
+.spells .spells-header-grid.arcane > div {
+  text-align: center;
+  margin: auto;
+  font-weight: bold;
+  width: 100%;
+}
+.spells div[data-groupname=repeating_arcane] > div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 4fr) minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr);
+  row-gap: 0;
+  column-gap: 2px;
+  background: aliceblue;
+}
+.spells div[data-groupname=repeating_arcane] > div input, .spells div[data-groupname=repeating_arcane] > div input[type=number], .spells div[data-groupname=repeating_arcane] > div textarea, .spells div[data-groupname=repeating_arcane] > div select {
+  width: 100%;
+  margin-left: unset;
+  background-color: white;
+}
+.spells div[data-groupname=repeating_arcane] > div input[type=text] {
+  text-align: left;
+}
+.spells div[data-groupname=repeating_arcane] > div input, .spells div[data-groupname=repeating_arcane] > div span, .spells div[data-groupname=repeating_arcane] > div select {
+  white-space: nowrap;
+}
+.spells div[data-groupname=repeating_arcane] > div span {
+  text-align: center;
+  margin: auto 0;
+}
+.spells div[data-groupname=repeating_arcane] > div button, .spells div[data-groupname=repeating_arcane] > div button[type=roll] {
+  margin: 0;
+}
+.spells div[data-groupname=repeating_arcane] > div .spell-row.conditional-one {
+  grid-column-start: 1;
+  grid-column-end: 19;
+}
+.spells .spells-header-grid.divine {
+  display: grid;
+  grid-template-columns: 6fr 1fr 1fr 2fr 1fr 1fr 2fr 0.5fr;
+  column-gap: 2px;
+  background: #93c6f2;
+  padding: 2px;
+}
+.spells .spells-header-grid.divine > div {
+  text-align: center;
+  margin: auto;
+  font-weight: bold;
+  width: 100%;
+}
+.spells div[data-groupname=repeating_divine] > div {
+  display: grid;
+  grid-template-columns: 6fr 1fr 1fr 2fr 1fr 1fr 2fr 0.5fr;
+  row-gap: 0;
+  column-gap: 2px;
+  background: aliceblue;
+}
+.spells div[data-groupname=repeating_divine] > div input, .spells div[data-groupname=repeating_divine] > div input[type=number], .spells div[data-groupname=repeating_divine] > div textarea, .spells div[data-groupname=repeating_divine] > div select {
+  width: 100%;
+  margin-left: unset;
+  background-color: white;
+}
+.spells div[data-groupname=repeating_divine] > div input[type=text] {
+  text-align: left;
+}
+.spells div[data-groupname=repeating_divine] > div input, .spells div[data-groupname=repeating_divine] > div span, .spells div[data-groupname=repeating_divine] > div select {
+  white-space: nowrap;
+}
+.spells div[data-groupname=repeating_divine] > div span {
+  text-align: center;
+  margin: auto 0;
+}
+.spells div[data-groupname=repeating_divine] > div button, .spells div[data-groupname=repeating_divine] > div button[type=roll] {
+  margin: 0;
+}
+.spells div[data-groupname=repeating_divine] > div .spell-row.conditional-one {
+  grid-column-start: 1;
+  grid-column-end: 9;
+}
+.spells .spells-header-grid.innate {
+  display: grid;
+  grid-template-columns: 6fr 1fr 2fr 3fr 2fr 3fr 2fr 0.5fr 1fr;
+  column-gap: 2px;
+  background: #93c6f2;
+  padding: 2px;
+}
+.spells .spells-header-grid.innate > div {
   text-align: center;
   margin: auto;
   font-weight: bold;
@@ -1109,19 +1200,28 @@ input.featCP {
 }
 .spells div[data-groupname=repeating_innate] > div {
   display: grid;
-  grid-template-columns: 4fr 1fr 1fr 2fr 1fr 2fr 2fr 1fr 1fr;
-  row-gap: 4px;
+  grid-template-columns: 6fr 1fr 2fr 3fr 2fr 3fr 2fr 0.5fr 1fr;
+  row-gap: 0;
   column-gap: 2px;
   background: aliceblue;
-  padding-left: 4px;
-  padding-right: 4px;
 }
-.spells div[data-groupname=repeating_innate] > div > input, .spells div[data-groupname=repeating_innate] > div input[type=number], .spells div[data-groupname=repeating_innate] > div > select {
+.spells div[data-groupname=repeating_innate] > div input, .spells div[data-groupname=repeating_innate] > div input[type=number], .spells div[data-groupname=repeating_innate] > div textarea, .spells div[data-groupname=repeating_innate] > div select {
   width: 100%;
   margin-left: unset;
+  background-color: white;
 }
-.spells div[data-groupname=repeating_innate] > div > input[type=text] {
+.spells div[data-groupname=repeating_innate] > div input[type=text] {
   text-align: left;
+}
+.spells div[data-groupname=repeating_innate] > div input, .spells div[data-groupname=repeating_innate] > div span, .spells div[data-groupname=repeating_innate] > div select {
+  white-space: nowrap;
+}
+.spells div[data-groupname=repeating_innate] > div span {
+  text-align: center;
+  margin: auto 0;
+}
+.spells div[data-groupname=repeating_innate] > div button, .spells div[data-groupname=repeating_innate] > div button[type=roll] {
+  margin: 0;
 }
 .spells div[data-groupname=repeating_innate] > div .spell-row.conditional-one {
   grid-column-start: 1;

--- a/bin/main.html
+++ b/bin/main.html
@@ -1001,37 +1001,35 @@
     </fieldset>
   </div>
 
-  <div class="innate section flex-stack">
+  <div class="innate section">
     <input name="attr_innate_total_CP" type="hidden" value="0" />
     <input name="attr_innate_total_single_CP" type="hidden" value="0" />
-    <div class="table-header">
-      <div class="skillname">Name</div>
-      <div class="spellEP">EP</div>
-      <div class="spellcasttime">Cast Time</div>
-      <div class="spelltype">Touch/ Ray/ Missile</div>
-      <div class="spellrange">Range</div>
-      <div class="spelltarget">Target</div>
-      <div class="spellduration">Duration</div>
-      <div class="spellhasnote">N</div>
-      <div class="skillCP">CP</div>
+    <div class="innate-spells-header">
+      <div class="skillname-grid">Name</div>
+      <div class="spellEP-grid">EP</div>
+      <div class="spellcasttime-grid">Cast Time</div>
+      <div class="spelltype-grid">Touch/ Ray/ Missile</div>
+      <div class="spellrange-grid">Range</div>
+      <div class="spelltarget-grid">Target</div>
+      <div class="spellduration-grid">Duration</div>
+      <div class="spellhasnote-grid">N</div>
+      <div class="skillCP-grid">CP</div>
     </div>
     <fieldset class="repeating_innate">
-      <div class="spell-row">
-        <input name="attr_skillname" class="skillname" type="text" />
-        <input name="attr_spellEP" class="spellEP" type="text" />
-        <input name="attr_spellcasttime" class="spellcasttime" type="text" />
-        <select name="attr_spelltype" class="spelltype" type="text">
-          <option value="-">None</option>
-          <option value="touch">Touch</option>
-          <option value="ray">Ray</option>
-          <option value="missile">Missile</option>
-        </select>
-        <input name="attr_spellrange" class="spellrange" type="text" />
-        <input name="attr_spelltarget" class="spelltarget" type="text" />
-        <input name="attr_spellduration" class="spellduration" type="text" />
-        <input name="attr_spellhasnote" class="spellhasnote" type="checkbox" value="1" />
-        <input name="attr_skillCP" class="skillCP" type="number" />
-      </div>
+      <input name="attr_skillname" class="skillname-grid" type="text" />
+      <input name="attr_spellEP" class="spellEP-grid" type="text" />
+      <input name="attr_spellcasttime" class="spellcasttime-grid" type="text" />
+      <select name="attr_spelltype" class="spelltype-grid" type="text">
+        <option value="-">None</option>
+        <option value="touch">Touch</option>
+        <option value="ray">Ray</option>
+        <option value="missile">Missile</option>
+      </select>
+      <input name="attr_spellrange" class="spellrange-grid" type="text" />
+      <input name="attr_spelltarget" class="spelltarget-grid" type="text" />
+      <input name="attr_spellduration" class="spellduration-grid" type="text" />
+      <input name="attr_spellhasnote" class="spellhasnote-grid" type="checkbox" value="1" />
+      <input name="attr_skillCP" class="skillCP-grid" type="number" />
       <div class="spell-row conditional-one">
         <!--
           The next input puts whether we have a note into the

--- a/bin/main.html
+++ b/bin/main.html
@@ -880,78 +880,76 @@
     <input name="attr_arcane_total_TP" type="hidden" value="0" />
     <input name="attr_arcane_total_CP" type="hidden" value="0" />
     <input name="attr_arcane_total_single_CP" type="hidden" value="0" />
-    <div class="table-header">
-      <div class="skilldisciplineinfo">Discipline?</div>
-      <div class="skillname">Name</div>
-      <div class="skillability">Ability</div>
-      <div class="skillbase">Mod</div>
-      <div class="skill-roll"></div>
-      <div class="spellEP">EP</div>
-      <div class="spellcasttime">Cast Time</div>
-      <div class="spelltype">Touch/ Ray/ Missile</div>
-      <div class="spellrange">Range</div>
-      <div class="spelltarget">Target</div>
-      <div class="spellduration">Damage/ Duration</div>
-      <div class="spellhasnote">N</div>
-      <div class="skillTP">TP</div>
-      <div class="skillCP">CP</div>
-      <div class="skillexpertise">Exper.</div>
-      <div class="skillattribute">IQ ±</div>
-      <div class="skillbase">Base</div>
+    <div class="arcane spells-header-grid">
+      <div class="skilldisciplineinfo-grid">Discipline?</div>
+      <div class="skillname-grid">Name</div>
+      <div class="skillability-grid">Ability</div>
+      <div class="skillbase-grid">Mod</div>
+      <div class="skill--gridroll"></div>
+      <div class="spellEP-grid">EP</div>
+      <div class="spellcasttime-grid">Cast Time</div>
+      <div class="spelltype-grid">Touch/ Ray/ Missile</div>
+      <div class="spellrange-grid">Range</div>
+      <div class="spelltarget-grid">Target</div>
+      <div class="spellduration-grid">Damage/ Duration</div>
+      <div class="spellhasnote-grid">N</div>
+      <div class="skillTP-grid">TP</div>
+      <div class="skillCP-grid">CP</div>
+      <div class="skillexpertise-grid">Exper.</div>
+      <div class="skillattribute-grid">IQ ±</div>
+      <div class="skillbase-grid">Base</div>
     </div>
     <fieldset class="repeating_arcane">
-      <div class="spell-row">
-        <select name="attr_skilldisciplineinfo" class="skilldisciplineinfo">
-          <option value=" "></option>
-          <option value="D">D</option>
-          <option value="⇡">⇡</option>
-        </select>
-        <!--
-          The next input puts whether we are a discipline into the
-          value property, where CSS can see it
-        -->
-        <input name="attr_skillisdiscipline" class="isdiscipline" type="hidden">
-        <input name="attr_skillname" class="skillname" type="text" />
-        <span name="attr_skillability" class="skillability"></span>
-        <!-- Make the button able to access the ability -->
-        <input name="attr_skillability" hidden="true" />
-        <input name="attr_skillmodifier" class="skillbase" type="number">
-        <button name="roll_spellroll" class="skill-roll" type="roll"
-          value="!EPRoll @{skillability}+@{skillmodifier} Tries @{skillname}: @{skillability} + @{skillmodifier}" />
-        </button>
-        <input name="attr_spellEP" class="spellEP" type="text" />
-        <input name="attr_spellcasttime" class="spellcasttime" type="text" />
-        <select name="attr_spelltype" class="spelltype" type="text">
-          <option value="-">None</option>
-          <option value="touch">Touch</option>
-          <option value="ray">Ray</option>
-          <option value="missile">Missile</option>
-        </select>
-        <input name="attr_spellrange" class="spellrange" type="text" />
-        <input name="attr_spelltarget" class="spelltarget" type="text" />
-        <input name="attr_spellduration" class="spellduration" type="text" />
-        <input name="attr_spellhasnote" class="spellhasnote" type="checkbox" value="1" />
-        <span name="attr_skillTP" class="skillTP center"></span>
-        <span name="attr_skillCP" class="skillCP center"></span>
-        <select name="attr_skillexpertise" class="skillexpertise">
-          <option value="--">--</option>
-          <option value="-1">-1</option>
-          <option value="0">0</option>
-          <option value="1">1</option>
-          <option value="2">2</option>
-          <option value="3">3</option>
-          <option value="4">4</option>
-          <option value="5">5</option>
-          <option value="6">6</option>
-          <option value="7">7</option>
-          <option value="8">8</option>
-          <option value="9">9</option>
-        </select>
-        <input name="attr_skilldisciplineexpertise" type="hidden" />
-        <input name="attr_skillattribute" value="IQ" type="hidden" />
-        <span class="skillattribute">IQ ±</span>
-        <input name="attr_skillbase" class="skillbase" type="number" value="" />
-      </div>
+      <select name="attr_skilldisciplineinfo" class="skilldisciplineinfo-grid">
+        <option value=" "></option>
+        <option value="D">D</option>
+        <option value="⇡">⇡</option>
+      </select>
+      <!--
+        The next input puts whether we are a discipline into the
+        value property, where CSS can see it
+      -->
+      <input name="attr_skillisdiscipline" class="isdiscipline-grid" type="hidden">
+      <input name="attr_skillname" class="skillname-grid" type="text" />
+      <span name="attr_skillability" class="skillability-grid"></span>
+      <!-- Make the button able to access the ability -->
+      <input name="attr_skillability" hidden="true" />
+      <input name="attr_skillmodifier" class="skillbase-grid" type="number">
+      <button name="roll_spellroll" class="skill-grid-roll" type="roll"
+        value="!EPRoll @{skillability}+@{skillmodifier} Tries @{skillname}: @{skillability} + @{skillmodifier}" />
+      </button>
+      <input name="attr_spellEP" class="spellEP-grid" type="text" />
+      <input name="attr_spellcasttime" class="spellcasttime-grid" type="text" />
+      <select name="attr_spelltype" class="spelltype-grid" type="text">
+        <option value="-">None</option>
+        <option value="touch">Touch</option>
+        <option value="ray">Ray</option>
+        <option value="missile">Missile</option>
+      </select>
+      <input name="attr_spellrange" class="spellrange-grid" type="text" />
+      <input name="attr_spelltarget" class="spelltarget-grid" type="text" />
+      <input name="attr_spellduration" class="spellduration-grid" type="text" />
+      <input name="attr_spellhasnote" class="spellhasnote-grid" type="checkbox" value="1" />
+      <span name="attr_skillTP" class="skillTP-grid center"></span>
+      <span name="attr_skillCP" class="skillCP-grid center"></span>
+      <select name="attr_skillexpertise" class="skillexpertise-grid">
+        <option value="--">--</option>
+        <option value="-1">-1</option>
+        <option value="0">0</option>
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+        <option value="6">6</option>
+        <option value="7">7</option>
+        <option value="8">8</option>
+        <option value="9">9</option>
+      </select>
+      <input name="attr_skilldisciplineexpertise" type="hidden" />
+      <input name="attr_skillattribute" value="IQ" type="hidden" />
+      <span class="skillattribute-grid">IQ ±</span>
+      <input name="attr_skillbase" class="skillbase-grid" type="number" value="" />
       <div class="spell-row conditional-one">
         <!-- The next input puts whether we have a note into the
           value property, where CSS can see it -->
@@ -961,35 +959,33 @@
     </fieldset>
   </div>
 
-  <div class="divine section flex-stack">
+  <div class="divine section divine-spells-grid">
     <input name="attr_divine_total_CP" type="hidden" value="0" />
     <input name="attr_divine_total_single_CP" type="hidden" value="0" />
-    <div class="table-header">
-      <div class="skillname">Name</div>
-      <div class="spellEP">EP</div>
-      <div class="spellcasttime">Cast Time</div>
-      <div class="spelltype">Touch/ Ray/ Missile</div>
-      <div class="spellrange">Range</div>
-      <div class="spelltarget">Target</div>
-      <div class="spellduration">Damage/ Duration</div>
-      <div class="spellhasnote">N</div>
+    <div class="divine spells-header-grid">
+      <div class="skillname-grid">Name</div>
+      <div class="spellEP-grid">EP</div>
+      <div class="spellcasttime-grid">Cast Time</div>
+      <div class="spelltype-grid">Touch/ Ray/ Missile</div>
+      <div class="spellrange-grid">Range</div>
+      <div class="spelltarget-grid">Target</div>
+      <div class="spellduration-grid">Damage/ Duration</div>
+      <div class="spellhasnote-grid">N</div>
     </div>
     <fieldset class="repeating_divine">
-      <div class="spell-row">
-        <input name="attr_skillname" class="skillname" type="text" />
-        <input name="attr_spellEP" class="spellEP" type="number" />
-        <input name="attr_spellcasttime" class="spellcasttime" type="text" />
-        <select name="attr_spelltype" class="spelltype" type="text">
-          <option value="-">None</option>
-          <option value="touch">Touch</option>
-          <option value="ray">Ray</option>
-          <option value="missile">Missile</option>
-        </select>
-        <input name="attr_spellrange" class="spellrange" type="text" />
-        <input name="attr_spelltarget" class="spelltarget" type="text" />
-        <input name="attr_spellduration" class="spellduration" type="text" />
-        <input name="attr_spellhasnote" class="spellhasnote" type="checkbox" value="1" />
-      </div>
+      <input name="attr_skillname" class="skillname-grid" type="text" />
+      <input name="attr_spellEP" class="spellEP-grid" type="number" />
+      <input name="attr_spellcasttime" class="spellcasttime-grid" type="text" />
+      <select name="attr_spelltype" class="spelltype-grid" type="text">
+        <option value="-">None</option>
+        <option value="touch">Touch</option>
+        <option value="ray">Ray</option>
+        <option value="missile">Missile</option>
+      </select>
+      <input name="attr_spellrange" class="spellrange-grid" type="text" />
+      <input name="attr_spelltarget" class="spelltarget-grid" type="text" />
+      <input name="attr_spellduration" class="spellduration-grid" type="text" />
+      <input name="attr_spellhasnote" class="spellhasnote-grid" type="checkbox" value="1" />
       <div class="spell-row conditional-one">
         <!--
           The next input puts whether we we have a note into the
@@ -1001,10 +997,10 @@
     </fieldset>
   </div>
 
-  <div class="innate section">
+  <div class="innate section innate-spells-grid">
     <input name="attr_innate_total_CP" type="hidden" value="0" />
     <input name="attr_innate_total_single_CP" type="hidden" value="0" />
-    <div class="innate-spells-header">
+    <div class="innate spells-header-grid">
       <div class="skillname-grid">Name</div>
       <div class="spellEP-grid">EP</div>
       <div class="spellcasttime-grid">Cast Time</div>

--- a/ui/epicSkills/epicSkills.scss
+++ b/ui/epicSkills/epicSkills.scss
@@ -25,6 +25,16 @@
   color: blue;
 }
 
+.skillTP-grid {
+  color: #319000;
+  font-weight: bold;
+}
+
+.skillCP-grid {
+  color: blue;
+  font-weight: bold;
+}
+
 .skillexpertise {
   width: 40px;
 }

--- a/ui/epicSkills/epicSkills.scss
+++ b/ui/epicSkills/epicSkills.scss
@@ -6,7 +6,6 @@
 .skillname {
   width: 150px;
   text-align: right;
-  border-left-color: black;
 }
 
 .skillability {
@@ -101,11 +100,7 @@
 .isdiscipline[value="1"]~.skillname {
   width: 190px;
   text-align: left;
-  border-top-color: black;
-  border-left-color: black;
   font-weight: bold;
-  /* Make the border go above other borders */
-  z-index: 1;
 }
 
 .isdiscipline[value="1"]~.skillability,

--- a/ui/roll20_character_sheet_0.2.html
+++ b/ui/roll20_character_sheet_0.2.html
@@ -1001,37 +1001,35 @@
     </fieldset>
   </div>
 
-  <div class="innate section flex-stack">
+  <div class="innate section innate-spells-grid">
     <input name="attr_innate_total_CP" type="hidden" value="0" />
     <input name="attr_innate_total_single_CP" type="hidden" value="0" />
-    <div class="table-header">
-      <div class="skillname">Name</div>
-      <div class="spellEP">EP</div>
-      <div class="spellcasttime">Cast Time</div>
-      <div class="spelltype">Touch/ Ray/ Missile</div>
-      <div class="spellrange">Range</div>
-      <div class="spelltarget">Target</div>
-      <div class="spellduration">Duration</div>
-      <div class="spellhasnote">N</div>
-      <div class="skillCP">CP</div>
+    <div class="innate-spells-header">
+      <div class="skillname-grid">Name</div>
+      <div class="spellEP-grid">EP</div>
+      <div class="spellcasttime-grid">Cast Time</div>
+      <div class="spelltype-grid">Touch/ Ray/ Missile</div>
+      <div class="spellrange-grid">Range</div>
+      <div class="spelltarget-grid">Target</div>
+      <div class="spellduration-grid">Duration</div>
+      <div class="spellhasnote-grid">N</div>
+      <div class="skillCP-grid">CP</div>
     </div>
     <fieldset class="repeating_innate">
-      <div class="spell-row">
-        <input name="attr_skillname" class="skillname" type="text" />
-        <input name="attr_spellEP" class="spellEP" type="text" />
-        <input name="attr_spellcasttime" class="spellcasttime" type="text" />
-        <select name="attr_spelltype" class="spelltype" type="text">
-          <option value="-">None</option>
-          <option value="touch">Touch</option>
-          <option value="ray">Ray</option>
-          <option value="missile">Missile</option>
-        </select>
-        <input name="attr_spellrange" class="spellrange" type="text" />
-        <input name="attr_spelltarget" class="spelltarget" type="text" />
-        <input name="attr_spellduration" class="spellduration" type="text" />
-        <input name="attr_spellhasnote" class="spellhasnote" type="checkbox" value="1" />
-        <input name="attr_skillCP" class="skillCP" type="number" />
-      </div>
+      <input name="attr_skillname" class="skillname-grid" type="text" />
+      <input name="attr_spellEP" class="spellEP-grid" type="text" />
+      <input name="attr_spellcasttime" class="spellcasttime-grid" type="text" />
+      <select name="attr_spelltype" class="spelltype-grid" type="text">
+        <option value="-">None</option>
+        <option value="touch">Touch</option>
+        <option value="ray">Ray</option>
+        <option value="missile">Missile</option>
+      </select>
+      <input name="attr_spellrange" class="spellrange-grid" type="text" />
+      <input name="attr_spelltarget" class="spelltarget-grid" type="text" />
+      <input name="attr_spellduration" class="spellduration-grid" type="text" />
+      <input name="attr_spellhasnote" class="spellhasnote-grid" type="checkbox" value="1" />
+      <input name="attr_skillCP" class="skillCP-grid" type="number" />
       <div class="spell-row conditional-one">
         <!--
           The next input puts whether we have a note into the

--- a/ui/roll20_character_sheet_0.2.html
+++ b/ui/roll20_character_sheet_0.2.html
@@ -880,78 +880,76 @@
     <input name="attr_arcane_total_TP" type="hidden" value="0" />
     <input name="attr_arcane_total_CP" type="hidden" value="0" />
     <input name="attr_arcane_total_single_CP" type="hidden" value="0" />
-    <div class="table-header">
-      <div class="skilldisciplineinfo">Discipline?</div>
-      <div class="skillname">Name</div>
-      <div class="skillability">Ability</div>
-      <div class="skillbase">Mod</div>
-      <div class="skill-roll"></div>
-      <div class="spellEP">EP</div>
-      <div class="spellcasttime">Cast Time</div>
-      <div class="spelltype">Touch/ Ray/ Missile</div>
-      <div class="spellrange">Range</div>
-      <div class="spelltarget">Target</div>
-      <div class="spellduration">Damage/ Duration</div>
-      <div class="spellhasnote">N</div>
-      <div class="skillTP">TP</div>
-      <div class="skillCP">CP</div>
-      <div class="skillexpertise">Exper.</div>
-      <div class="skillattribute">IQ ±</div>
-      <div class="skillbase">Base</div>
+    <div class="arcane spells-header-grid">
+      <div class="skilldisciplineinfo-grid">Discipline?</div>
+      <div class="skillname-grid">Name</div>
+      <div class="skillability-grid">Ability</div>
+      <div class="skillbase-grid">Mod</div>
+      <div class="skill--gridroll"></div>
+      <div class="spellEP-grid">EP</div>
+      <div class="spellcasttime-grid">Cast Time</div>
+      <div class="spelltype-grid">Touch/ Ray/ Missile</div>
+      <div class="spellrange-grid">Range</div>
+      <div class="spelltarget-grid">Target</div>
+      <div class="spellduration-grid">Damage/ Duration</div>
+      <div class="spellhasnote-grid">N</div>
+      <div class="skillTP-grid">TP</div>
+      <div class="skillCP-grid">CP</div>
+      <div class="skillexpertise-grid">Exper.</div>
+      <div class="skillattribute-grid">IQ ±</div>
+      <div class="skillbase-grid">Base</div>
     </div>
     <fieldset class="repeating_arcane">
-      <div class="spell-row">
-        <select name="attr_skilldisciplineinfo" class="skilldisciplineinfo">
-          <option value=" "></option>
-          <option value="D">D</option>
-          <option value="⇡">⇡</option>
-        </select>
-        <!--
-          The next input puts whether we are a discipline into the
-          value property, where CSS can see it
-        -->
-        <input name="attr_skillisdiscipline" class="isdiscipline" type="hidden">
-        <input name="attr_skillname" class="skillname" type="text" />
-        <span name="attr_skillability" class="skillability"></span>
-        <!-- Make the button able to access the ability -->
-        <input name="attr_skillability" hidden="true" />
-        <input name="attr_skillmodifier" class="skillbase" type="number">
-        <button name="roll_spellroll" class="skill-roll" type="roll"
-          value="!EPRoll @{skillability}+@{skillmodifier} Tries @{skillname}: @{skillability} + @{skillmodifier}" />
-        </button>
-        <input name="attr_spellEP" class="spellEP" type="text" />
-        <input name="attr_spellcasttime" class="spellcasttime" type="text" />
-        <select name="attr_spelltype" class="spelltype" type="text">
-          <option value="-">None</option>
-          <option value="touch">Touch</option>
-          <option value="ray">Ray</option>
-          <option value="missile">Missile</option>
-        </select>
-        <input name="attr_spellrange" class="spellrange" type="text" />
-        <input name="attr_spelltarget" class="spelltarget" type="text" />
-        <input name="attr_spellduration" class="spellduration" type="text" />
-        <input name="attr_spellhasnote" class="spellhasnote" type="checkbox" value="1" />
-        <span name="attr_skillTP" class="skillTP center"></span>
-        <span name="attr_skillCP" class="skillCP center"></span>
-        <select name="attr_skillexpertise" class="skillexpertise">
-          <option value="--">--</option>
-          <option value="-1">-1</option>
-          <option value="0">0</option>
-          <option value="1">1</option>
-          <option value="2">2</option>
-          <option value="3">3</option>
-          <option value="4">4</option>
-          <option value="5">5</option>
-          <option value="6">6</option>
-          <option value="7">7</option>
-          <option value="8">8</option>
-          <option value="9">9</option>
-        </select>
-        <input name="attr_skilldisciplineexpertise" type="hidden" />
-        <input name="attr_skillattribute" value="IQ" type="hidden" />
-        <span class="skillattribute">IQ ±</span>
-        <input name="attr_skillbase" class="skillbase" type="number" value="" />
-      </div>
+      <select name="attr_skilldisciplineinfo" class="skilldisciplineinfo-grid">
+        <option value=" "></option>
+        <option value="D">D</option>
+        <option value="⇡">⇡</option>
+      </select>
+      <!--
+        The next input puts whether we are a discipline into the
+        value property, where CSS can see it
+      -->
+      <input name="attr_skillisdiscipline" class="isdiscipline-grid" type="hidden">
+      <input name="attr_skillname" class="skillname-grid" type="text" />
+      <span name="attr_skillability" class="skillability-grid"></span>
+      <!-- Make the button able to access the ability -->
+      <input name="attr_skillability" hidden="true" />
+      <input name="attr_skillmodifier" class="skillbase-grid" type="number">
+      <button name="roll_spellroll" class="skill-grid-roll" type="roll"
+        value="!EPRoll @{skillability}+@{skillmodifier} Tries @{skillname}: @{skillability} + @{skillmodifier}" />
+      </button>
+      <input name="attr_spellEP" class="spellEP-grid" type="text" />
+      <input name="attr_spellcasttime" class="spellcasttime-grid" type="text" />
+      <select name="attr_spelltype" class="spelltype-grid" type="text">
+        <option value="-">None</option>
+        <option value="touch">Touch</option>
+        <option value="ray">Ray</option>
+        <option value="missile">Missile</option>
+      </select>
+      <input name="attr_spellrange" class="spellrange-grid" type="text" />
+      <input name="attr_spelltarget" class="spelltarget-grid" type="text" />
+      <input name="attr_spellduration" class="spellduration-grid" type="text" />
+      <input name="attr_spellhasnote" class="spellhasnote-grid" type="checkbox" value="1" />
+      <span name="attr_skillTP" class="skillTP-grid center"></span>
+      <span name="attr_skillCP" class="skillCP-grid center"></span>
+      <select name="attr_skillexpertise" class="skillexpertise-grid">
+        <option value="--">--</option>
+        <option value="-1">-1</option>
+        <option value="0">0</option>
+        <option value="1">1</option>
+        <option value="2">2</option>
+        <option value="3">3</option>
+        <option value="4">4</option>
+        <option value="5">5</option>
+        <option value="6">6</option>
+        <option value="7">7</option>
+        <option value="8">8</option>
+        <option value="9">9</option>
+      </select>
+      <input name="attr_skilldisciplineexpertise" type="hidden" />
+      <input name="attr_skillattribute" value="IQ" type="hidden" />
+      <span class="skillattribute-grid">IQ ±</span>
+      <input name="attr_skillbase" class="skillbase-grid" type="number" value="" />
       <div class="spell-row conditional-one">
         <!-- The next input puts whether we have a note into the
           value property, where CSS can see it -->
@@ -961,35 +959,33 @@
     </fieldset>
   </div>
 
-  <div class="divine section flex-stack">
+  <div class="divine section divine-spells-grid">
     <input name="attr_divine_total_CP" type="hidden" value="0" />
     <input name="attr_divine_total_single_CP" type="hidden" value="0" />
-    <div class="table-header">
-      <div class="skillname">Name</div>
-      <div class="spellEP">EP</div>
-      <div class="spellcasttime">Cast Time</div>
-      <div class="spelltype">Touch/ Ray/ Missile</div>
-      <div class="spellrange">Range</div>
-      <div class="spelltarget">Target</div>
-      <div class="spellduration">Damage/ Duration</div>
-      <div class="spellhasnote">N</div>
+    <div class="divine spells-header-grid">
+      <div class="skillname-grid">Name</div>
+      <div class="spellEP-grid">EP</div>
+      <div class="spellcasttime-grid">Cast Time</div>
+      <div class="spelltype-grid">Touch/ Ray/ Missile</div>
+      <div class="spellrange-grid">Range</div>
+      <div class="spelltarget-grid">Target</div>
+      <div class="spellduration-grid">Damage/ Duration</div>
+      <div class="spellhasnote-grid">N</div>
     </div>
     <fieldset class="repeating_divine">
-      <div class="spell-row">
-        <input name="attr_skillname" class="skillname" type="text" />
-        <input name="attr_spellEP" class="spellEP" type="number" />
-        <input name="attr_spellcasttime" class="spellcasttime" type="text" />
-        <select name="attr_spelltype" class="spelltype" type="text">
-          <option value="-">None</option>
-          <option value="touch">Touch</option>
-          <option value="ray">Ray</option>
-          <option value="missile">Missile</option>
-        </select>
-        <input name="attr_spellrange" class="spellrange" type="text" />
-        <input name="attr_spelltarget" class="spelltarget" type="text" />
-        <input name="attr_spellduration" class="spellduration" type="text" />
-        <input name="attr_spellhasnote" class="spellhasnote" type="checkbox" value="1" />
-      </div>
+      <input name="attr_skillname" class="skillname-grid" type="text" />
+      <input name="attr_spellEP" class="spellEP-grid" type="number" />
+      <input name="attr_spellcasttime" class="spellcasttime-grid" type="text" />
+      <select name="attr_spelltype" class="spelltype-grid" type="text">
+        <option value="-">None</option>
+        <option value="touch">Touch</option>
+        <option value="ray">Ray</option>
+        <option value="missile">Missile</option>
+      </select>
+      <input name="attr_spellrange" class="spellrange-grid" type="text" />
+      <input name="attr_spelltarget" class="spelltarget-grid" type="text" />
+      <input name="attr_spellduration" class="spellduration-grid" type="text" />
+      <input name="attr_spellhasnote" class="spellhasnote-grid" type="checkbox" value="1" />
       <div class="spell-row conditional-one">
         <!--
           The next input puts whether we we have a note into the
@@ -1004,7 +1000,7 @@
   <div class="innate section innate-spells-grid">
     <input name="attr_innate_total_CP" type="hidden" value="0" />
     <input name="attr_innate_total_single_CP" type="hidden" value="0" />
-    <div class="innate-spells-header">
+    <div class="innate spells-header-grid">
       <div class="skillname-grid">Name</div>
       <div class="spellEP-grid">EP</div>
       <div class="spellcasttime-grid">Cast Time</div>

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -12,10 +12,7 @@
 }
 
 .sectioncontrol[value="arcane"]~div.arcane,
-.sectioncontrol[value="divine"]~div.divine {
-  display: inline-flex;
-}
-
+.sectioncontrol[value="divine"]~div.divine,
 .sectioncontrol[value="innate"]~div.innate {
   display: block;
 }
@@ -129,44 +126,108 @@
     margin-top: -1px;
   }
 
-  $innate-grid: 4fr 1fr 1fr 2fr 1fr 2fr 2fr 1fr 1fr;
-  $innate-grid-padding: 4px;
-  $innate-grid-column-gap: 2px;
+  $grid-padding: 2px;
+  $grid-column-gap: 2px;
 
-  .innate-spells-header {
+  @mixin spells-header($grid-template) {
     display: grid;
-    grid-template-columns: $innate-grid;
-    column-gap: $innate-grid-column-gap;
+    grid-template-columns: $grid-template;
+    column-gap: $grid-column-gap;
     background: #93c6f2;
-    padding: $innate-grid-padding;
-    >div {
-        text-align: center;
-        margin: auto;
-        font-weight: bold;
-        width: 100%;
-      }
+    padding: $grid-padding;
+
+    > div {
+      text-align: center;
+      margin: auto;
+      font-weight: bold;
+      width: 100%;
+    }
   }
 
-  div[data-groupname="repeating_innate"] > div {
+  @mixin spells-rows($grid-template, $column-count) {
     display: grid;
-    grid-template-columns: $innate-grid;
-    row-gap: 4px;
-    column-gap: $innate-grid-column-gap;
+    grid-template-columns: $grid-template;
+    row-gap: 0;
+    column-gap: $grid-column-gap;
     background: aliceblue;
-    padding-left: $innate-grid-padding;
-    padding-right: $innate-grid-padding;
-    > input, input[type=number], > select {
+    input, input[type=number], textarea, select {
       width: 100%;
       margin-left: unset;
+      background-color: white;
     }
-    > input[type=text] {
+    input[type=text] {
       text-align: left;
     }
+    input, span, select {
+      white-space: nowrap;
+    }
+    span {
+      text-align: center;
+      margin: auto 0;
+    }
+    button, button[type=roll] {
+      margin: 0;
+    }
     .spell-row.conditional-one {
+      // This makes the notes span all columns
       grid-column-start: 1;
-      grid-column-end: 10;
+      grid-column-end: ($column-count + 1);
     }
   }
+
+  @mixin spells-grid($spell-type, $grid-template, $column-count) {
+    .spells-header-grid.#{$spell-type} {
+      @include spells-header($grid-template);
+    }
+
+    div[data-groupname="repeating_#{$spell-type}"] > div {
+      @include spells-rows($grid-template, $column-count);
+    }
+  }
+
+  $arcane-grid-template:
+    // Discipline?
+    minmax(0, 1fr)
+    // Name
+    minmax(0, 4fr)
+    // Ability
+    minmax(0, 0.75fr)
+    // Mod
+    minmax(0, 1fr)
+    // (Dice)
+    minmax(0, 0.5fr)
+    // EP
+    minmax(0, 1fr)
+    // Cast Time
+    minmax(0, 1fr)
+    // Touch/ Ray/ Missile
+    minmax(0, 2fr)
+    // Range
+    minmax(0, 1fr)
+    // Target
+    minmax(0, 1fr)
+    // Damage/ Duration
+    minmax(0, 1.5fr)
+    // N(otes)
+    minmax(0, 0.5fr)
+    // TP
+    minmax(0, 0.5fr)
+    // CP
+    minmax(0, 0.5fr)
+    // Exper.
+    minmax(0, 1fr)
+    // IQ ±
+    minmax(0, 0.5fr)
+    // Base
+    minmax(0, 1fr);
+
+  @include spells-grid('arcane', $arcane-grid-template, 18);
+
+  $divine-grid-template: 6fr 1fr 1fr 2fr 1fr 1fr 2fr 0.5fr;
+  @include spells-grid('divine', $divine-grid-template, 8);
+
+  $innate-grid-template: 6fr 1fr 2fr 3fr 2fr 3fr 2fr 0.5fr 1fr;
+  @include spells-grid('innate', $innate-grid-template, 9);
 }
 
 .spell-row {

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -12,9 +12,12 @@
 }
 
 .sectioncontrol[value="arcane"]~div.arcane,
-.sectioncontrol[value="divine"]~div.divine,
-.sectioncontrol[value="innate"]~div.innate {
+.sectioncontrol[value="divine"]~div.divine {
   display: inline-flex;
+}
+
+.sectioncontrol[value="innate"]~div.innate {
+  display: block;
 }
 
 .spell-tabs {
@@ -124,6 +127,45 @@
     align-items: stretch;
     /* and make rows overlap */
     margin-top: -1px;
+  }
+
+  $innate-grid: 4fr 1fr 1fr 2fr 1fr 2fr 2fr 1fr 1fr;
+  $innate-grid-padding: 4px;
+  $innate-grid-column-gap: 2px;
+
+  .innate-spells-header {
+    display: grid;
+    grid-template-columns: $innate-grid;
+    column-gap: $innate-grid-column-gap;
+    background: #93c6f2;
+    padding: $innate-grid-padding;
+    >div {
+        text-align: center;
+        margin: auto;
+        font-weight: bold;
+        width: 100%;
+      }
+  }
+
+  div[data-groupname="repeating_innate"] > div {
+    display: grid;
+    grid-template-columns: $innate-grid;
+    row-gap: 4px;
+    column-gap: $innate-grid-column-gap;
+    background: aliceblue;
+    padding-left: $innate-grid-padding;
+    padding-right: $innate-grid-padding;
+    > input, input[type=number], > select {
+      width: 100%;
+      margin-left: unset;
+    }
+    > input[type=text] {
+      text-align: left;
+    }
+    .spell-row.conditional-one {
+      grid-column-start: 1;
+      grid-column-end: 10;
+    }
   }
 }
 


### PR DESCRIPTION
Add styles and colors to help differentiate the header.
This also automatically fixes #5 
Convert to `grid` to help with responsiveness and alignment of columns.

# Examples:

## Arcane

![image](https://user-images.githubusercontent.com/5629800/208278630-dbe13624-0538-4ac2-9f7a-0411dba18553.png)
![image](https://user-images.githubusercontent.com/5629800/208278616-62257c0b-0b2b-42ff-a8a0-c5898da8f3ea.png)
![image](https://user-images.githubusercontent.com/5629800/208278622-727df492-d31c-4bda-851a-740864deb403.png)

### Example with narrow screen
![image](https://user-images.githubusercontent.com/5629800/208278733-d2585273-9e2a-43f0-8dac-e639a16768f3.png)


## Divine

![image](https://user-images.githubusercontent.com/5629800/208278660-bea0262f-a720-4362-bfed-1118ed3a3236.png)
![image](https://user-images.githubusercontent.com/5629800/208278648-c5eaac72-90b9-48ee-9dd1-97fc7fb8674b.png)

### Example with narrow screen
![image](https://user-images.githubusercontent.com/5629800/208278739-b76303a0-36f3-4615-9391-70375c18b89e.png)

## Innate

![image](https://user-images.githubusercontent.com/5629800/208278684-c8541cd4-a61a-413f-a6ea-719fe76acecc.png)
![image](https://user-images.githubusercontent.com/5629800/208278681-c9a7d102-d4c1-4133-b4fe-ac1da8dfd01e.png)

### Example with narrow screen
![image](https://user-images.githubusercontent.com/5629800/208278746-8846e095-8f7d-47cb-92a4-0dddbaa0a0f3.png)
