### PR TITLE
Make Overview tab only show taken advantages

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -767,6 +767,11 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 2;
 }
+.overview-tab .advantage-overview input.advantageField:not([value]) ~ .advantage-row,
+.overview-tab .advantage-overview input.advantageField[value=""] ~ .advantage-row,
+.overview-tab .advantage-overview input.advantageField[value=" "] ~ .advantage-row {
+  display: none;
+}
 .overview-tab .advantage-overview .advantage-row {
   display: flex;
   justify-content: space-between;

--- a/bin/main.html
+++ b/bin/main.html
@@ -378,7 +378,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_healthy_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_healthy_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Healthy</div>
             <span class="advantage-value" name="attr_advantage_healthy_count"></span>
@@ -387,7 +388,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_packmule_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_packmule_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Pack Mule</div>
             <span class="advantage-value" name="attr_advantage_packmule_count"></span>
@@ -396,7 +398,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_strongarms_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_strongarms_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Strong Arms</div>
             <span class="advantage-value" name="attr_advantage_strongarms_count"></span>
@@ -405,7 +408,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_brute_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_brute_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Brute</div>
             <span class="advantage-value" name="attr_advantage_brute_count"></span>
@@ -414,7 +418,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_fast_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_fast_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Fast</div>
             <span class="advantage-value" name="attr_advantage_fast_count"></span>
@@ -423,7 +428,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_athlete_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_athlete_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Natural Athlete</div>
             <span class="advantage-value" name="attr_advantage_athlete_count"></span>
@@ -432,7 +438,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_alert_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_alert_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Alert</div>
             <span class="advantage-value" name="attr_advantage_alert_count"></span>
@@ -441,7 +448,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_wary_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_wary_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Wary</div>
             <span class="advantage-value" name="attr_advantage_wary_count"></span>
@@ -450,7 +458,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_mage_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_mage_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Mage</div>
             <span class="advantage-value" name="attr_advantage_mage_count"></span>
@@ -459,7 +468,8 @@
       </div>
       <div class="advantage-table" data-epic-table-name="advantage">
         <div class="conditional-something">
-          <input name="attr_advantage_devout_count" type="hidden" />
+          <!-- This input is used by CSS to hide advantage-row-->
+          <input class="advantageField" name="attr_advantage_devout_count" type="hidden" />
           <div class="advantage-row">
             <div class="advantage-name">Devout</div>
             <span class="advantage-value" name="attr_advantage_devout_count"></span>

--- a/ui/overviewTab/overviewTab.pug
+++ b/ui/overviewTab/overviewTab.pug
@@ -10,7 +10,8 @@ include ../global/advantages.pug
       each advantage in advantages
         .advantage-table(data-epic-table-name="advantage")
           .conditional-something
-            input(name=advantage.fieldName type='hidden')
+            // This input is used by CSS to hide advantage-row
+            input.advantageField(name=advantage.fieldName type='hidden')
             .advantage-row
               div.advantage-name=advantage.description
               span.advantage-value(name=advantage.fieldName)

--- a/ui/overviewTab/overviewTab.scss
+++ b/ui/overviewTab/overviewTab.scss
@@ -13,11 +13,18 @@
     display: flex;
     gap: 16px;
   }
-
+  
   .advantage-overview {
     $advantage-grid-template: getResponsiveGridWidths(128px);
     @include epic-table-grid('advantage', $advantage-grid-template);
     @include epic-table-grid('extraadvantage', $advantage-grid-template);
+
+    input.advantageField:not([value])~.advantage-row,
+    input.advantageField[value=""]~.advantage-row,
+    input.advantageField[value=" "]~.advantage-row {
+      // Hide the .advantage-row
+      display: none;
+    }
 
     .advantage-row {
       display: flex;


### PR DESCRIPTION
Fix #46

The overview tab should only show
advantages that the character has taken.

![image](https://user-images.githubusercontent.com/5629800/210684905-018c7837-822f-42a5-b6dc-1a8a218f454a.png)
