### PR TITLE
Fix Delete option on skills panel, adjust skill/spell columns

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -1807,7 +1807,7 @@ radio > span.checked {
 }
 .spells .epic-table-header-grid.arcane {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 24px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1821,7 +1821,7 @@ radio > span.checked {
 .spells div[data-groupname=repeating_arcane] > div,
 .spells div[data-epic-table-name=arcane] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 24px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;

--- a/bin/main.css
+++ b/bin/main.css
@@ -1438,6 +1438,8 @@ radio > span.checked {
 .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillattribute-grid,
 .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillbase-grid {
   opacity: 0;
+  cursor: default;
+  pointer-events: none;
 }
 .epic-skills-tab .skillTP-grid, .epic-skills-tab .TP-grid {
   color: #267200;

--- a/bin/main.css
+++ b/bin/main.css
@@ -1377,7 +1377,7 @@ radio > span.checked {
 /* -------- Skills --------- */
 .epic-skills-tab .epic-table-header-grid.skill {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 5fr) minmax(0, 36px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1391,7 +1391,7 @@ radio > span.checked {
 .epic-skills-tab div[data-groupname=repeating_skill] > div,
 .epic-skills-tab div[data-epic-table-name=skill] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 5fr) minmax(0, 36px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;

--- a/bin/main.css
+++ b/bin/main.css
@@ -1805,7 +1805,7 @@ radio > span.checked {
 }
 .spells .epic-table-header-grid.arcane {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 88px) minmax(0, 40px) minmax(0, 40px) minmax(0, 1.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1819,7 +1819,7 @@ radio > span.checked {
 .spells div[data-groupname=repeating_arcane] > div,
 .spells div[data-epic-table-name=arcane] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 88px) minmax(0, 40px) minmax(0, 40px) minmax(0, 1.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;

--- a/bin/main.css
+++ b/bin/main.css
@@ -1377,7 +1377,7 @@ radio > span.checked {
 /* -------- Skills --------- */
 .epic-skills-tab .epic-table-header-grid.skill {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1391,7 +1391,7 @@ radio > span.checked {
 .epic-skills-tab div[data-groupname=repeating_skill] > div,
 .epic-skills-tab div[data-epic-table-name=skill] {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1431,15 +1431,19 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 9;
 }
-.epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillname-grid {
-  font-weight: bold;
-}
 .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillability-grid,
 .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillattribute-grid,
 .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillbase-grid {
   opacity: 0;
   cursor: default;
   pointer-events: none;
+}
+.epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillname-grid {
+  font-weight: bold;
+  text-align: center;
+}
+.epic-skills-tab .isdiscipline-grid:not([value="1"]) ~ .skillname-grid {
+  text-align: right;
 }
 .epic-skills-tab .skillTP-grid, .epic-skills-tab .TP-grid {
   color: #267200;
@@ -1803,7 +1807,7 @@ radio > span.checked {
 }
 .spells .epic-table-header-grid.arcane {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 4fr) minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1817,7 +1821,7 @@ radio > span.checked {
 .spells div[data-groupname=repeating_arcane] > div,
 .spells div[data-epic-table-name=arcane] {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 4fr) minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 0.75fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1856,6 +1860,13 @@ radio > span.checked {
   display: grid;
   grid-column-start: 1;
   grid-column-end: 18;
+}
+.spells .isdiscipline-grid[value="1"] ~ .skillname-grid {
+  font-weight: bold;
+  text-align: center;
+}
+.spells .isdiscipline-grid:not([value="1"]) ~ .skillname-grid {
+  text-align: right;
 }
 .spells .arcane-iq-plus-minus-attribute {
   white-space: nowrap;

--- a/bin/main.css
+++ b/bin/main.css
@@ -1431,9 +1431,7 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 9;
 }
-.epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillability-grid,
-.epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillattribute-grid,
-.epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillbase-grid {
+.epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillability-grid, .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillattribute-grid, .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillbase-grid {
   opacity: 0;
   cursor: default;
   pointer-events: none;
@@ -1807,7 +1805,7 @@ radio > span.checked {
 }
 .spells .epic-table-header-grid.arcane {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 24px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1821,7 +1819,7 @@ radio > span.checked {
 .spells div[data-groupname=repeating_arcane] > div,
 .spells div[data-epic-table-name=arcane] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 24px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1.5fr) minmax(0, 0.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1860,6 +1858,11 @@ radio > span.checked {
   display: grid;
   grid-column-start: 1;
   grid-column-end: 18;
+}
+.spells .isdiscipline-grid[value="1"] ~ :not(.skillname-grid, .skillTP-grid, .skillexpertise-grid) {
+  opacity: 0;
+  cursor: default;
+  pointer-events: none;
 }
 .spells .isdiscipline-grid[value="1"] ~ .skillname-grid {
   font-weight: bold;

--- a/ui/epicSkills/epicSkills.scss
+++ b/ui/epicSkills/epicSkills.scss
@@ -15,7 +15,7 @@
   );
   @include epic-table-grid('skill', $skill-grid-template);
 
-    .isdiscipline-grid[value="1"]~.skillname-grid {
+  .isdiscipline-grid[value="1"]~.skillname-grid {
     font-weight: bold;
   }
 
@@ -23,6 +23,8 @@
   .isdiscipline-grid[value="1"]~.skillattribute-grid,
   .isdiscipline-grid[value="1"]~.skillbase-grid {
     opacity: 0;
+    cursor: default;
+    pointer-events: none;
   }
 
   @include grid-table-tp-cp-columns();

--- a/ui/epicSkills/epicSkills.scss
+++ b/ui/epicSkills/epicSkills.scss
@@ -15,12 +15,12 @@
   );
   @include epic-table-grid('skill', $skill-grid-template);
 
-  .isdiscipline-grid[value="1"]~.skillability-grid,
-  .isdiscipline-grid[value="1"]~.skillattribute-grid,
-  .isdiscipline-grid[value="1"]~.skillbase-grid {
-    opacity: 0;
-    cursor: default;
-    pointer-events: none;
+  .isdiscipline-grid[value="1"] {
+    ~.skillability-grid, ~.skillattribute-grid, ~.skillbase-grid {
+      opacity: 0;
+      cursor: default;
+      pointer-events: none;
+    }
   }
   .isdiscipline-grid[value="1"]~.skillname-grid {
     font-weight: bold;

--- a/ui/epicSkills/epicSkills.scss
+++ b/ui/epicSkills/epicSkills.scss
@@ -4,7 +4,7 @@
 /* -------- Skills --------- */
 .epic-skills-tab {
   $skill-grid-template: getResponsiveGridWidths(
-    1fr, // Discipline?
+    40px, // Discipline?
     5fr, // Name
     1fr, // Ability
     0.5fr, // TP
@@ -15,10 +15,6 @@
   );
   @include epic-table-grid('skill', $skill-grid-template);
 
-  .isdiscipline-grid[value="1"]~.skillname-grid {
-    font-weight: bold;
-  }
-
   .isdiscipline-grid[value="1"]~.skillability-grid,
   .isdiscipline-grid[value="1"]~.skillattribute-grid,
   .isdiscipline-grid[value="1"]~.skillbase-grid {
@@ -26,6 +22,12 @@
     cursor: default;
     pointer-events: none;
   }
-
+  .isdiscipline-grid[value="1"]~.skillname-grid {
+    font-weight: bold;
+    text-align: center;
+  }
+  .isdiscipline-grid:not([value="1"])~.skillname-grid {
+    text-align: right;
+  }
   @include grid-table-tp-cp-columns();
 }

--- a/ui/epicSkills/epicSkills.scss
+++ b/ui/epicSkills/epicSkills.scss
@@ -6,9 +6,9 @@
   $skill-grid-template: getResponsiveGridWidths(
     40px, // Discipline?
     5fr, // Name
-    1fr, // Ability
-    0.5fr, // TP
-    0.5fr, // CP
+    36px, // Ability
+    24px, // TP
+    24px, // CP
     1fr, // Exper
     2fr, // Attribute
     1fr // Base

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -135,7 +135,7 @@
   $arcane-grid-template: getResponsiveGridWidths(
     40px, // Discipline?
     4fr, // Name
-    0.75fr, // Ability
+    24px, // Ability
     1fr, // Mod
     0.5fr, // (Dice)
     1fr, // EP
@@ -145,10 +145,10 @@
     1fr, // Target
     1.5fr, // Damage/ Duration
     0.5fr, // N(otes)
-    0.5fr, // TP
-    0.5fr, // CP
+    24px, // TP
+    24px, // CP
     1fr, // Exper.
-    0.5fr, // IQ ±
+    auto, // IQ ±
     1fr, // Base
   );
 

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -135,7 +135,7 @@
   $arcane-grid-template: getResponsiveGridWidths(
     40px, // Discipline?
     4fr, // Name
-    24px, // Ability
+    32px, // Ability
     1fr, // Mod
     0.5fr, // (Dice)
     1fr, // EP
@@ -153,6 +153,13 @@
   );
 
   @include epic-table-grid('arcane', $arcane-grid-template);
+  .isdiscipline-grid[value="1"] {
+    ~:not(.skillname-grid, .skillTP-grid, .skillexpertise-grid) {
+      opacity: 0;
+      cursor: default;
+      pointer-events: none;
+    }
+  }
 
   .isdiscipline-grid[value="1"]~.skillname-grid {
     font-weight: bold;

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -138,18 +138,18 @@
     32px, // Ability
     1fr, // Mod
     0.5fr, // (Dice)
-    1fr, // EP
+    40px, // EP
     1fr, // Cast Time
-    2fr, // Touch/ Ray/ Missile
-    1fr, // Range
-    1fr, // Target
+    88px, // Touch/ Ray/ Missile
+    40px, // Range
+    40px, // Target
     1.5fr, // Damage/ Duration
-    0.5fr, // N(otes)
+    24px, // N(otes)
     24px, // TP
     24px, // CP
-    1fr, // Exper.
+    40px, // Exper.
     auto, // IQ ±
-    1fr, // Base
+    40px, // Base
   );
 
   @include epic-table-grid('arcane', $arcane-grid-template);

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -133,7 +133,7 @@
   }
 
   $arcane-grid-template: getResponsiveGridWidths(
-    1fr, // Discipline?
+    40px, // Discipline?
     4fr, // Name
     0.75fr, // Ability
     1fr, // Mod
@@ -153,6 +153,14 @@
   );
 
   @include epic-table-grid('arcane', $arcane-grid-template);
+
+  .isdiscipline-grid[value="1"]~.skillname-grid {
+    font-weight: bold;
+    text-align: center;
+  }
+  .isdiscipline-grid:not([value="1"])~.skillname-grid {
+    text-align: right;
+  }
 
   .arcane-iq-plus-minus-attribute {
     white-space: nowrap;


### PR DESCRIPTION
Ref Some issues with skill formatting #48

`opacity: 0` causes unusual behaviors such as being able to click the select even though it is invisible, and it also breaks the repeating delete function.

Both are fixed by making the fields be `pointer-events: none`

The error is seen in the skills tab at the end of this video:

https://user-images.githubusercontent.com/5629800/211176481-ad27daf7-1c1e-4784-a8fd-96ca6629775d.mp4

Fixed:

https://user-images.githubusercontent.com/5629800/211176758-a699c372-2407-4b73-9287-cab7b4c1e81e.mp4

Also, fix some styles:
![image](https://user-images.githubusercontent.com/5629800/211177298-e2b5aee9-2cc1-4b3f-b199-078605d4f109.png)
![image](https://user-images.githubusercontent.com/5629800/211177723-5ec74145-2354-4e17-a0c4-23d0cb407ac1.png)

