### PR TITLE
Fix a few issues and styles

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -72,6 +72,29 @@ div.popoverContainer > .fixedPlacementPopover {
   right: 20vw;
 }
 
+.epic-tooltip {
+  position: relative;
+  display: inline-block;
+}
+.epic-tooltip .epic-tooltip-text {
+  visibility: hidden;
+  max-width: 300px;
+  word-break: normal;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 4px;
+  padding: 4px;
+  /* Position the tooltip */
+  position: absolute;
+  z-index: 1;
+  top: 105%;
+  left: 0;
+}
+.epic-tooltip:hover .epic-tooltip-text {
+  visibility: visible;
+}
+
 /* Styles that apply everywhere */
 .characterviewer label,
 .characterviewer .label {

--- a/bin/main.css
+++ b/bin/main.css
@@ -129,6 +129,11 @@ button.actionRollButton {
   border-radius: 4px;
   background-image: linear-gradient(90deg, rgb(245, 201, 162), #c2815b);
 }
+button.btn.ui-draggable[type=roll]:hover,
+button.actionRollButton:hover {
+  background-image: unset;
+  background-color: #c2815b;
+}
 
 button.btn.ui-draggable[type=roll]::before,
 button.actionRollButton::before {
@@ -160,6 +165,11 @@ button.do-and-roll {
   border-radius: 4px;
   background-image: linear-gradient(90deg, rgb(245, 201, 162), #c2815b);
 }
+button.do:hover,
+button.do-and-roll:hover {
+  background-image: unset;
+  background-color: #c2815b;
+}
 
 button.do {
   width: 18px;
@@ -173,10 +183,18 @@ button.big-control.do-and-roll {
   background-image: linear-gradient(90deg, #ddd, #ddd);
   pointer-events: none;
 }
+.disable-do[value="1"] ~ .do:hover {
+  background-image: unset;
+  background-color: #c2815b;
+}
 
 .disable-do-and-roll[value="1"] ~ .do-and-roll {
   background-image: linear-gradient(90deg, #ddd, #ddd);
   pointer-events: none;
+}
+.disable-do-and-roll[value="1"] ~ .do-and-roll:hover {
+  background-image: unset;
+  background-color: #c2815b;
 }
 
 /* Change the character for undo buttons to be
@@ -195,6 +213,10 @@ button.undo {
   line-height: 1;
   padding: 1px 1px;
 }
+button.undo:hover {
+  background-image: unset;
+  background-color: rgb(138, 103, 103);
+}
 
 button.reset-total {
   font-weight: bold;
@@ -206,6 +228,10 @@ button.reset-total {
   padding: 2px;
   vertical-align: middle;
 }
+button.reset-total:hover {
+  background-image: unset;
+  background-color: #c2815b;
+}
 
 button.convert-button {
   font-weight: bold;
@@ -216,6 +242,10 @@ button.convert-button {
   padding: 0px 2px 4px 2px;
   vertical-align: middle;
   font-size: 200%;
+}
+button.convert-button:hover {
+  background-image: unset;
+  background-color: #c2815b;
 }
 
 /* Generic styles */
@@ -717,6 +747,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .overview-tab .advantage-overview .epic-table-header-grid.advantage > div {
   text-align: center;
@@ -773,6 +804,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .overview-tab .advantage-overview .epic-table-header-grid.extraadvantage > div {
   text-align: center;
@@ -855,11 +887,12 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .overview-tab .feat-overview .epic-table-header-grid.feat {
   display: grid;
-  grid-template-columns: minmax(0, 24px) minmax(0, 96px);
+  grid-template-columns: minmax(0, 32px) minmax(0, 96px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .overview-tab .feat-overview .epic-table-header-grid.feat > div {
   text-align: center;
@@ -869,7 +902,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .overview-tab .feat-overview div[data-groupname=repeating_feat] > div,
 .overview-tab .feat-overview div[data-epic-table-name=feat] {
   display: grid;
-  grid-template-columns: minmax(0, 24px) minmax(0, 96px);
+  grid-template-columns: minmax(0, 32px) minmax(0, 96px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -927,11 +960,12 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .overview-tab .skills-overview .epic-table-header-grid.skills-table {
   display: grid;
-  grid-template-columns: minmax(0, 96px) minmax(0, 32px) minmax(0, 32px) minmax(0, 24px);
+  grid-template-columns: minmax(0, 96px) minmax(0, 36px) minmax(0, 36px) minmax(0, 24px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .overview-tab .skills-overview .epic-table-header-grid.skills-table > div {
   text-align: center;
@@ -941,7 +975,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .overview-tab .skills-overview div[data-groupname=repeating_skills-table] > div,
 .overview-tab .skills-overview div[data-epic-table-name=skills-table] {
   display: grid;
-  grid-template-columns: minmax(0, 96px) minmax(0, 32px) minmax(0, 32px) minmax(0, 24px);
+  grid-template-columns: minmax(0, 96px) minmax(0, 36px) minmax(0, 36px) minmax(0, 24px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1011,11 +1045,12 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .overview-tab .weapons-overview .epic-table-header-grid.weapons-table {
   display: grid;
-  grid-template-columns: minmax(0, 128px) minmax(0, 48px) minmax(0, 60px) minmax(0, 32px);
+  grid-template-columns: minmax(0, 128px) minmax(0, 48px) minmax(0, 60px) minmax(0, 56px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .overview-tab .weapons-overview .epic-table-header-grid.weapons-table > div {
   text-align: center;
@@ -1025,7 +1060,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .overview-tab .weapons-overview div[data-groupname=repeating_weapons-table] > div,
 .overview-tab .weapons-overview div[data-epic-table-name=weapons-table] {
   display: grid;
-  grid-template-columns: minmax(0, 128px) minmax(0, 48px) minmax(0, 60px) minmax(0, 32px);
+  grid-template-columns: minmax(0, 128px) minmax(0, 48px) minmax(0, 60px) minmax(0, 56px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1072,6 +1107,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .overview-tab .weapons-overview .epic-table-header-grid.weapons-equipmentnotes-table > div {
   text-align: center;
@@ -1163,6 +1199,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .basic-tab .character-attributes .epic-table-header-grid.character-attributes > div {
   text-align: center;
@@ -1227,6 +1264,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .basic-tab .advantages .epic-table-header-grid.advantage > div {
   text-align: center;
@@ -1283,6 +1321,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .basic-tab .advantages .epic-table-header-grid.extraadvantage > div {
   text-align: center;
@@ -1357,11 +1396,12 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .basic-tab .feats .epic-table-header-grid.feat {
   display: grid;
-  grid-template-columns: minmax(0, 24px) minmax(0, 160px) minmax(0, 48px);
+  grid-template-columns: minmax(0, 32px) minmax(0, 160px) minmax(0, 48px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .basic-tab .feats .epic-table-header-grid.feat > div {
   text-align: center;
@@ -1371,7 +1411,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .basic-tab .feats div[data-groupname=repeating_feat] > div,
 .basic-tab .feats div[data-epic-table-name=feat] {
   display: grid;
-  grid-template-columns: minmax(0, 24px) minmax(0, 160px) minmax(0, 48px);
+  grid-template-columns: minmax(0, 32px) minmax(0, 160px) minmax(0, 48px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1437,6 +1477,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .epic-skills-tab .epic-table-header-grid.skill > div {
   text-align: center;
@@ -1521,6 +1562,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .equipment-tab .epic-table-header-grid.armor > div {
   text-align: center;
@@ -1577,6 +1619,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .equipment-tab .epic-table-header-grid.shield > div {
   text-align: center;
@@ -1633,6 +1676,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .equipment-tab .epic-table-header-grid.weapon > div {
   text-align: center;
@@ -1689,6 +1733,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .equipment-tab .epic-table-header-grid.item > div {
   text-align: center;
@@ -1776,11 +1821,12 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .spells .epic-table-header-grid.arcane {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 88px) minmax(0, 40px) minmax(0, 40px) minmax(0, 1.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 40px) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 72px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 16px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .spells .epic-table-header-grid.arcane > div {
   text-align: center;
@@ -1790,7 +1836,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .spells div[data-groupname=repeating_arcane] > div,
 .spells div[data-epic-table-name=arcane] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 1fr) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 88px) minmax(0, 40px) minmax(0, 40px) minmax(0, 1.5fr) minmax(0, 24px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 40px) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 72px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 16px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1835,6 +1881,10 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   cursor: default;
   pointer-events: none;
 }
+.spells .skillname-hidden[value|="----"] ~ .skillname-grid {
+  font-weight: bold;
+  text-align: center;
+}
 .spells .isdiscipline-grid[value="1"] ~ .skillname-grid {
   font-weight: bold;
   text-align: center;
@@ -1847,11 +1897,12 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .spells .epic-table-header-grid.divine {
   display: grid;
-  grid-template-columns: minmax(0, 6fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 0.5fr);
+  grid-template-columns: minmax(0, 6fr) minmax(0, 16px) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .spells .epic-table-header-grid.divine > div {
   text-align: center;
@@ -1861,7 +1912,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .spells div[data-groupname=repeating_divine] > div,
 .spells div[data-epic-table-name=divine] {
   display: grid;
-  grid-template-columns: minmax(0, 6fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 0.5fr);
+  grid-template-columns: minmax(0, 6fr) minmax(0, 16px) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1903,11 +1954,12 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .spells .epic-table-header-grid.innate {
   display: grid;
-  grid-template-columns: minmax(0, 6fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 0.5fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 6fr) minmax(0, 16px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
   padding: 2px;
+  word-break: break-word;
 }
 .spells .epic-table-header-grid.innate > div {
   text-align: center;
@@ -1917,7 +1969,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .spells div[data-groupname=repeating_innate] > div,
 .spells div[data-epic-table-name=innate] {
   display: grid;
-  grid-template-columns: minmax(0, 6fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 0.5fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 6fr) minmax(0, 16px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;

--- a/bin/main.css
+++ b/bin/main.css
@@ -1836,6 +1836,27 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .spells .spell-header-action-area label, .spells .spell-header-action-area .label {
   color: black;
 }
+.spells .spellNotesPopover button.popoverButton {
+  font-family: Pictos;
+  font-size: 12px;
+  line-height: 18px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  border-radius: 100%;
+  padding: 0 !important;
+  color: #c4bdaf;
+  background-color: #b56632;
+}
+.spells .spellNotesPopover .spellnote-hidden[value] ~ button.popoverButton::after {
+  content: "s";
+  color: #80ffff;
+}
+.spells .spellNotesPopover .spellnote-hidden:not([value]) ~ button.popoverButton::after, .spells .spellNotesPopover .spellnote-hidden[value=""] ~ button.popoverButton::after {
+  content: "&";
+  color: #efcb83;
+}
 .spells .epic-table-header-grid.arcane {
   display: grid;
   grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 40px) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 80px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 16px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);

--- a/bin/main.css
+++ b/bin/main.css
@@ -259,10 +259,6 @@ button.convert-button:hover {
   padding-bottom: 16px;
 }
 
-.invisible {
-  display: none;
-}
-
 .inline {
   display: inline-block;
 }
@@ -281,10 +277,6 @@ button.convert-button:hover {
 
 .middle {
   vertical-align: middle;
-}
-
-.full-width {
-  width: 100%;
 }
 
 .narrow.narrow.narrow {
@@ -311,10 +303,6 @@ button.convert-button:hover {
   width: 90px;
 }
 
-.wider.wider.wider {
-  width: 150px;
-}
-
 .narrow-spacing {
   line-height: 1;
 }
@@ -329,26 +317,6 @@ button.convert-button:hover {
 
 .inlne-spacer {
   width: 8px;
-}
-
-.horizontal-flex {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-}
-
-.flex-gap {
-  gap: 16px;
-}
-
-.horizontal-flex-center {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.align-center.align-center.align-center {
-  align-items: center;
 }
 
 .flexing {
@@ -382,10 +350,6 @@ button.convert-button:hover {
 }
 
 .bold {
-  font-weight: bold;
-}
-
-.number.ability {
   font-weight: bold;
 }
 
@@ -589,6 +553,10 @@ radio > span.checked {
   margin-bottom: 6px;
   background: linear-gradient(to top, rgba(194, 148, 91, 0.5019607843) 0%, transparent 100%);
 }
+.top-section .attribute-row {
+  display: flex;
+  align-items: center;
+}
 
 .sectioncontrol[value=weightPenalties] ~ div.popoverContainer.weightPenalties,
 input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties {
@@ -736,7 +704,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   /* ------------ Skills Overview -------------- */
   /* ------------ Weapons Overview -------------- */
 }
-.overview-tab > .horizontal-flex {
+.overview-tab .tables-container {
   display: flex;
   gap: 16px;
 }
@@ -1569,6 +1537,10 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 
 /* -------- Equipment --------- */
+.equipment-tab .cash-and-equipment-summary {
+  display: flex;
+  gap: 16px;
+}
 .equipment-tab .epic-table-header-grid.armor {
   display: grid;
   grid-template-columns: minmax(0, 5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 5fr);
@@ -1834,6 +1806,10 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 
 /* Avoid space between items in the row */
+.spells .spell-header-action-area {
+  display: flex;
+  gap: 8px;
+}
 .spells .spell-header-action-area label, .spells .spell-header-action-area .label {
   color: black;
 }

--- a/bin/main.css
+++ b/bin/main.css
@@ -1453,7 +1453,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .epic-skills-tab .epic-table-header-grid.skill {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 40px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 40px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 40px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 72px) minmax(0, 40px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1468,7 +1468,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .epic-skills-tab div[data-groupname=repeating_skill] > div,
 .epic-skills-tab div[data-epic-table-name=skill] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 40px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 40px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 40px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 72px) minmax(0, 40px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1876,10 +1876,6 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   cursor: default;
   pointer-events: none;
 }
-.spells .skillname-hidden[value|="----"] ~ .skillname-grid {
-  font-weight: bold;
-  text-align: center;
-}
 .spells .isdiscipline-grid[value="1"] ~ .skillname-grid {
   font-weight: bold;
   text-align: center;
@@ -1950,7 +1946,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .spells .epic-table-header-grid.innate {
   display: grid;
-  grid-template-columns: minmax(0, 6fr) minmax(0, 16px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 6fr) minmax(0, 16px) minmax(0, 32px) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1965,7 +1961,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .spells div[data-groupname=repeating_innate] > div,
 .spells div[data-epic-table-name=innate] {
   display: grid;
-  grid-template-columns: minmax(0, 6fr) minmax(0, 16px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 6fr) minmax(0, 16px) minmax(0, 32px) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -2004,7 +2000,16 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .spells div[data-epic-table-name=innate] .epic-table-row.conditional-one {
   display: grid;
   grid-column-start: 1;
-  grid-column-end: 10;
+  grid-column-end: 11;
+}
+.spells .innatesphere-hidden[value|=S] ~ .skillname-grid {
+  font-weight: bold;
+  text-align: center;
+}
+.spells .innatesphere-hidden[value|=S] ~ :not(.skillname-grid) {
+  opacity: 0;
+  cursor: default;
+  pointer-events: none;
 }
 .spells .skillTP-grid, .spells .TP-grid {
   color: #267200;

--- a/bin/main.css
+++ b/bin/main.css
@@ -761,6 +761,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .overview-tab .advantage-overview div[data-groupname=repeating_advantage] > div input, .overview-tab .advantage-overview div[data-groupname=repeating_advantage] > div input[type=number], .overview-tab .advantage-overview div[data-groupname=repeating_advantage] > div textarea, .overview-tab .advantage-overview div[data-groupname=repeating_advantage] > div select,
 .overview-tab .advantage-overview div[data-epic-table-name=advantage] input,
@@ -818,6 +819,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .overview-tab .advantage-overview div[data-groupname=repeating_extraadvantage] > div input, .overview-tab .advantage-overview div[data-groupname=repeating_extraadvantage] > div input[type=number], .overview-tab .advantage-overview div[data-groupname=repeating_extraadvantage] > div textarea, .overview-tab .advantage-overview div[data-groupname=repeating_extraadvantage] > div select,
 .overview-tab .advantage-overview div[data-epic-table-name=extraadvantage] input,
@@ -906,6 +908,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .overview-tab .feat-overview div[data-groupname=repeating_feat] > div input, .overview-tab .feat-overview div[data-groupname=repeating_feat] > div input[type=number], .overview-tab .feat-overview div[data-groupname=repeating_feat] > div textarea, .overview-tab .feat-overview div[data-groupname=repeating_feat] > div select,
 .overview-tab .feat-overview div[data-epic-table-name=feat] input,
@@ -979,6 +982,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .overview-tab .skills-overview div[data-groupname=repeating_skills-table] > div input, .overview-tab .skills-overview div[data-groupname=repeating_skills-table] > div input[type=number], .overview-tab .skills-overview div[data-groupname=repeating_skills-table] > div textarea, .overview-tab .skills-overview div[data-groupname=repeating_skills-table] > div select,
 .overview-tab .skills-overview div[data-epic-table-name=skills-table] input,
@@ -1064,6 +1068,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .overview-tab .weapons-overview div[data-groupname=repeating_weapons-table] > div input, .overview-tab .weapons-overview div[data-groupname=repeating_weapons-table] > div input[type=number], .overview-tab .weapons-overview div[data-groupname=repeating_weapons-table] > div textarea, .overview-tab .weapons-overview div[data-groupname=repeating_weapons-table] > div select,
 .overview-tab .weapons-overview div[data-epic-table-name=weapons-table] input,
@@ -1121,6 +1126,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .overview-tab .weapons-overview div[data-groupname=repeating_weapons-equipmentnotes-table] > div input, .overview-tab .weapons-overview div[data-groupname=repeating_weapons-equipmentnotes-table] > div input[type=number], .overview-tab .weapons-overview div[data-groupname=repeating_weapons-equipmentnotes-table] > div textarea, .overview-tab .weapons-overview div[data-groupname=repeating_weapons-equipmentnotes-table] > div select,
 .overview-tab .weapons-overview div[data-epic-table-name=weapons-equipmentnotes-table] input,
@@ -1213,6 +1219,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .basic-tab .character-attributes div[data-groupname=repeating_character-attributes] > div input, .basic-tab .character-attributes div[data-groupname=repeating_character-attributes] > div input[type=number], .basic-tab .character-attributes div[data-groupname=repeating_character-attributes] > div textarea, .basic-tab .character-attributes div[data-groupname=repeating_character-attributes] > div select,
 .basic-tab .character-attributes div[data-epic-table-name=character-attributes] input,
@@ -1278,6 +1285,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .basic-tab .advantages div[data-groupname=repeating_advantage] > div input, .basic-tab .advantages div[data-groupname=repeating_advantage] > div input[type=number], .basic-tab .advantages div[data-groupname=repeating_advantage] > div textarea, .basic-tab .advantages div[data-groupname=repeating_advantage] > div select,
 .basic-tab .advantages div[data-epic-table-name=advantage] input,
@@ -1335,6 +1343,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .basic-tab .advantages div[data-groupname=repeating_extraadvantage] > div input, .basic-tab .advantages div[data-groupname=repeating_extraadvantage] > div input[type=number], .basic-tab .advantages div[data-groupname=repeating_extraadvantage] > div textarea, .basic-tab .advantages div[data-groupname=repeating_extraadvantage] > div select,
 .basic-tab .advantages div[data-epic-table-name=extraadvantage] input,
@@ -1415,6 +1424,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .basic-tab .feats div[data-groupname=repeating_feat] > div input, .basic-tab .feats div[data-groupname=repeating_feat] > div input[type=number], .basic-tab .feats div[data-groupname=repeating_feat] > div textarea, .basic-tab .feats div[data-groupname=repeating_feat] > div select,
 .basic-tab .feats div[data-epic-table-name=feat] input,
@@ -1494,6 +1504,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .epic-skills-tab div[data-groupname=repeating_skill] > div input, .epic-skills-tab div[data-groupname=repeating_skill] > div input[type=number], .epic-skills-tab div[data-groupname=repeating_skill] > div textarea, .epic-skills-tab div[data-groupname=repeating_skill] > div select,
 .epic-skills-tab div[data-epic-table-name=skill] input,
@@ -1579,6 +1590,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .equipment-tab div[data-groupname=repeating_armor] > div input, .equipment-tab div[data-groupname=repeating_armor] > div input[type=number], .equipment-tab div[data-groupname=repeating_armor] > div textarea, .equipment-tab div[data-groupname=repeating_armor] > div select,
 .equipment-tab div[data-epic-table-name=armor] input,
@@ -1636,6 +1648,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .equipment-tab div[data-groupname=repeating_shield] > div input, .equipment-tab div[data-groupname=repeating_shield] > div input[type=number], .equipment-tab div[data-groupname=repeating_shield] > div textarea, .equipment-tab div[data-groupname=repeating_shield] > div select,
 .equipment-tab div[data-epic-table-name=shield] input,
@@ -1693,6 +1706,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .equipment-tab div[data-groupname=repeating_weapon] > div input, .equipment-tab div[data-groupname=repeating_weapon] > div input[type=number], .equipment-tab div[data-groupname=repeating_weapon] > div textarea, .equipment-tab div[data-groupname=repeating_weapon] > div select,
 .equipment-tab div[data-epic-table-name=weapon] input,
@@ -1750,6 +1764,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .equipment-tab div[data-groupname=repeating_item] > div input, .equipment-tab div[data-groupname=repeating_item] > div input[type=number], .equipment-tab div[data-groupname=repeating_item] > div textarea, .equipment-tab div[data-groupname=repeating_item] > div select,
 .equipment-tab div[data-epic-table-name=item] input,
@@ -1843,6 +1858,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .spells div[data-groupname=repeating_arcane] > div input, .spells div[data-groupname=repeating_arcane] > div input[type=number], .spells div[data-groupname=repeating_arcane] > div textarea, .spells div[data-groupname=repeating_arcane] > div select,
 .spells div[data-epic-table-name=arcane] input,
@@ -1919,6 +1935,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .spells div[data-groupname=repeating_divine] > div input, .spells div[data-groupname=repeating_divine] > div input[type=number], .spells div[data-groupname=repeating_divine] > div textarea, .spells div[data-groupname=repeating_divine] > div select,
 .spells div[data-epic-table-name=divine] input,
@@ -1976,6 +1993,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
+  word-break: break-word;
 }
 .spells div[data-groupname=repeating_innate] > div input, .spells div[data-groupname=repeating_innate] > div input[type=number], .spells div[data-groupname=repeating_innate] > div textarea, .spells div[data-groupname=repeating_innate] > div select,
 .spells div[data-epic-table-name=innate] input,

--- a/bin/main.css
+++ b/bin/main.css
@@ -1470,9 +1470,12 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 
 /* -------- Skills --------- */
+.epic-skills-tab {
+  max-width: 600px;
+}
 .epic-skills-tab .epic-table-header-grid.skill {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 5fr) minmax(0, 36px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 40px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 40px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1487,7 +1490,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .epic-skills-tab div[data-groupname=repeating_skill] > div,
 .epic-skills-tab div[data-epic-table-name=skill] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 5fr) minmax(0, 36px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 40px) minmax(0, 24px) minmax(0, 24px) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 40px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -1821,7 +1824,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 }
 .spells .epic-table-header-grid.arcane {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 40px) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 72px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 16px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 40px) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 80px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 16px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -1836,7 +1839,7 @@ input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popov
 .spells div[data-groupname=repeating_arcane] > div,
 .spells div[data-epic-table-name=arcane] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 40px) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 72px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 16px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 40px) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 80px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 16px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;

--- a/bin/main.html
+++ b/bin/main.html
@@ -109,7 +109,7 @@
     These are read only, except in the basic tab,
     where they can be changed, and their CP cost is shown
     -->
-    <div class="horizontal-flex-center">
+    <div class="attribute-row">
       <input class="attributecontrol cpcontrol" name="attr_chosentab" type="hidden" value="basic" />
       <div class="attribute-name big">IQ</div>
       &ensp;
@@ -178,7 +178,7 @@
           <div class="popoverBackdrop">
             <button name="act_popover_weightPenalties" type="action">Close popover</button>
           </div>
-          <div class="flex-stack align-center popover">
+          <div class="popover">
             <button class="closePopoverButton" name="act_popover_weightPenalties" type="action">X</button>
             <div class="center wideish bold">Weight Penalties</div>
             <div class="weight-penalty-table flex-stack">
@@ -311,7 +311,7 @@ its value is used for css selection of its siblings.
 <input class="sectioncontrol" name="attr_chosentab" type="hidden" value="basic" />
 <!-- Overview section -->
 <div class="overview section overview-tab">
-  <div class="horizontal-flex">
+  <div class="tables-container">
     <!-- Advantages -->
     <div class="advantage-overview no-add-or-modify-buttons">
       <div class="advantage epic-table-header-grid">
@@ -484,7 +484,7 @@ its value is used for css selection of its siblings.
 </div>
 <!-- Basic section -->
 <div class="basic section basic-tab">
-  <div class="advantages-and-feats horizontal-flex">
+  <div class="advantages-and-feats">
     <!-- Character Attributes -->
     <div class="character-attributes">
       <div class="character-attributes epic-table-header-grid">
@@ -644,8 +644,8 @@ its value is used for css selection of its siblings.
 
 <!-- skill section -->
 <div class="skills section epic-skills-tab">
-  <div class="flex-stack full-width">
-    <div class="center bold">Disciplines &amp; Skills</div>
+  <div>
+    <div class="bold">Disciplines &amp; Skills</div>
   </div>
   <div class="epic-skill-table">
     <input name="attr_skill_total_TP" type="hidden" value="0" />
@@ -705,22 +705,22 @@ its value is used for css selection of its siblings.
 
 <!-- Equipment section -->
 <div class="equipment section equipment-tab">
-  <div class="horizontal-flex flex-gap">
+  <div class="cash-and-equipment-summary">
     <div>
-      <div class="attribute-name wideish larger inline bold right middle">Cash</div>
+      <div class="attribute-name larger inline bold right middle">Cash</div>
       <input class="wide center bold larger value" name="attr_cash" type="number" />
     </div>
     <div>
       <div class="attribute-name larger inline bold right middle">Equip Value</div>
-      <span class="narrowish center bold larger value middle" name="attr_equipment_total_value"></span>
+      <span class="center bold larger value middle" name="attr_equipment_total_value"></span>
     </div>
     <div>
       <div class="attribute-name larger inline bold right middle">Equip Weight</div>
-      <span class="narrowish center bold larger value middle" name="attr_equipment_total_weight"></span>
+      <span class="center bold larger value middle" name="attr_equipment_total_weight"></span>
     </div>
   </div>
 
-  <div class="spacer"></div>
+  <div class="small-spacer"></div>
   <div class="armor-table">
     <div class="armor-shield-weapons-tables">
       <div class="epic-table-header-grid armor">
@@ -804,7 +804,7 @@ its value is used for css selection of its siblings.
 </div>
 
 <!-- Spells section -->
-<div class="spells section horizontal-flex">
+<div class="spells section">
   <!--
   This input's value names the currently selected tab.
   its value is used for css selection of the tab content.
@@ -825,12 +825,12 @@ its value is used for css selection of its siblings.
     <div class="spell-header-action-area">
       <div class="label wide larger">Spell Touch</div>
       <input name="attr_spell_touch" type="hidden" />
-      <span class="center narrowish bold larger middle" name="attr_spell_touch"></span>
+      <span class="center bold larger middle" name="attr_spell_touch"></span>
       <button type="roll" value="!EPRoll @{spell_touch} Touches with Spell: @{spell_touch}"></button>
       &emsp;
       <div class="label wide larger">Aim Spell</div>
       <input name="attr_aim_spell" type="hidden" />
-      <span class="center narrowish bold larger middle" name="attr_aim_spell"></span>
+      <span class="center bold larger middle" name="attr_aim_spell"></span>
       <button type="roll" value="!EPRoll @{aim_spell} Aims Spell: @{aim_spell}"></button>
     </div>
   </div>

--- a/bin/main.html
+++ b/bin/main.html
@@ -886,8 +886,9 @@ its value is used for css selection of its siblings.
       <input class="spellrange-grid" name="attr_spellrange" type="text" />
       <input class="spelltarget-grid" name="attr_spelltarget" type="text" />
       <input class="spellduration-grid" name="attr_spellduration" type="text" />
-      <div>
-        <button class="popoverButton noPaddingButton" name="act_togglepopoverspellnote" type="action">&#128269;</button>
+      <div class="spellNotesPopover">
+        <input class="spellnote-hidden" name="attr_spellnote" type="hidden" />
+        <button class="popoverButton" name="act_togglepopoverspellnote" type="action"></button>
         <!--
         The next input puts whether we have a note into the
         value property, where CSS can see it
@@ -949,8 +950,9 @@ its value is used for css selection of its siblings.
     </div>
     <fieldset class="repeating_divine">
       <input class="skillname-grid" name="attr_skillname" type="text" />
-      <div>
-        <button class="popoverButton noPaddingButton" name="act_togglepopoverspellnote" type="action">&#128269;</button>
+      <div class="spellNotesPopover">
+        <input class="spellnote-hidden" name="attr_spellnote" type="hidden" />
+        <button class="popoverButton" name="act_togglepopoverspellnote" type="action"></button>
         <!--
         The next input puts whether we have a note into the
         value property, where CSS can see it
@@ -1012,8 +1014,9 @@ its value is used for css selection of its siblings.
       <!-- The next input allows targeting in CSS-->
       <input class="innatesphere-hidden" name="attr_skillinnatesphere" type="hidden" />
       <input class="skillname-grid" name="attr_skillname" type="text" />
-      <div>
-        <button class="popoverButton noPaddingButton" name="act_togglepopoverspellnote" type="action">&#128269;</button>
+      <div class="spellNotesPopover">
+        <input class="spellnote-hidden" name="attr_spellnote" type="hidden" />
+        <button class="popoverButton" name="act_togglepopoverspellnote" type="action"></button>
         <!--
         The next input puts whether we have a note into the
         value property, where CSS can see it

--- a/bin/main.html
+++ b/bin/main.html
@@ -992,6 +992,7 @@ its value is used for css selection of its siblings.
     <input name="attr_innate_total_CP" type="hidden" value="0" />
     <input name="attr_innate_total_single_CP" type="hidden" value="0" />
     <div class="innate epic-table-header-grid">
+      <div class="skill-innatesphere-grid">Sphere?</div>
       <div class="skillname-grid">Name</div>
       <div class="spellhasnote-grid">N</div>
       <div class="spellEP-grid">EP</div>
@@ -1003,8 +1004,12 @@ its value is used for css selection of its siblings.
       <div class="skillCP-grid">CP</div>
     </div>
     <fieldset class="repeating_innate">
+      <select class="skill-innatesphere-grid" name="attr_skillinnatesphere">
+        <option value=" "></option>
+        <option value="S">S</option>
+      </select>
       <!-- The next input allows targeting in CSS-->
-      <input class="skillname-hidden" name="attr_skillname" type="hidden" />
+      <input class="innatesphere-hidden" name="attr_skillinnatesphere" type="hidden" />
       <input class="skillname-grid" name="attr_skillname" type="text" />
       <div>
         <button class="popoverButton noPaddingButton" name="act_togglepopoverspellnote" type="action">&#128269;</button>

--- a/bin/main.html
+++ b/bin/main.html
@@ -992,7 +992,8 @@ its value is used for css selection of its siblings.
     <input name="attr_innate_total_CP" type="hidden" value="0" />
     <input name="attr_innate_total_single_CP" type="hidden" value="0" />
     <div class="innate epic-table-header-grid">
-      <div class="skill-innatesphere-grid">Sphere?</div>
+      <div class="skill-innatesphere-grid epic-tooltip">Sph<span class="epic-tooltip-text">Spell Sphere</span>
+      </div>
       <div class="skillname-grid">Name</div>
       <div class="spellhasnote-grid">N</div>
       <div class="spellEP-grid">EP</div>

--- a/bin/main.html
+++ b/bin/main.html
@@ -939,16 +939,42 @@ its value is used for css selection of its siblings.
     <input name="attr_divine_total_single_CP" type="hidden" value="0" />
     <div class="divine epic-table-header-grid">
       <div class="skillname-grid">Name</div>
+      <div class="spellhasnote-grid">N</div>
       <div class="spellEP-grid">EP</div>
       <div class="spellcasttime-grid">Cast Time</div>
       <div class="spelltype-grid">Touch/ Ray/ Missile</div>
       <div class="spellrange-grid">Range</div>
       <div class="spelltarget-grid">Target</div>
       <div class="spellduration-grid">Damage/ Duration</div>
-      <div class="spellhasnote-grid">N</div>
     </div>
     <fieldset class="repeating_divine">
       <input class="skillname-grid" name="attr_skillname" type="text" />
+      <div>
+        <button class="popoverButton noPaddingButton" name="act_togglepopoverspellnote" type="action">&#128269;</button>
+        <!--
+        The next input puts whether we have a note into the
+        value property, where CSS can see it
+        -->
+        <input class="popoverController" name="attr_visiblepopover" type="hidden" value="false" />
+        <div class="spellNotePopover popoverContainer">
+          <div class="popoverBackdrop">
+            <button name="act_closepopoverspellnotes" type="action">Close popover</button>
+          </div>
+          <div class="popover fixedPlacementPopover">
+            <!-- Buttons in a popover break stacking order, and pop out of the repeating stack.-->
+            <button class="closePopoverButton" name="act_closepopoverspellnotes" type="action">X</button>
+            <h2>
+              <span class="spell-name" name="attr_skillname"></span>
+            </h2>
+            <div class="small-spacer"></div>
+            <label>Name</label>
+            <input class="skillname-grid" name="attr_skillname" type="text" />
+            <label>Spell Notes</label>
+            <textarea class="spell-note" name="attr_spellnote" rows="6"></textarea>
+            <button name="act_closepopoverspellnotes" type="action">Close</button>
+          </div>
+        </div>
+      </div>
       <input class="spellEP-grid" name="attr_spellEP" type="number" />
       <input class="spellcasttime-grid" name="attr_spellcasttime" type="text" />
       <select class="spelltype-grid" name="attr_spelltype" type="text">
@@ -960,6 +986,26 @@ its value is used for css selection of its siblings.
       <input class="spellrange-grid" name="attr_spellrange" type="text" />
       <input class="spelltarget-grid" name="attr_spelltarget" type="text" />
       <input class="spellduration-grid" name="attr_spellduration" type="text" />
+    </fieldset>
+  </div>
+  <div class="innate section innate-spells-grid">
+    <input name="attr_innate_total_CP" type="hidden" value="0" />
+    <input name="attr_innate_total_single_CP" type="hidden" value="0" />
+    <div class="innate epic-table-header-grid">
+      <div class="skillname-grid">Name</div>
+      <div class="spellhasnote-grid">N</div>
+      <div class="spellEP-grid">EP</div>
+      <div class="spellcasttime-grid">Cast Time</div>
+      <div class="spelltype-grid">Touch/ Ray/ Missile</div>
+      <div class="spellrange-grid">Range</div>
+      <div class="spelltarget-grid">Target</div>
+      <div class="spellduration-grid">Damage/ Duration</div>
+      <div class="skillCP-grid">CP</div>
+    </div>
+    <fieldset class="repeating_innate">
+      <!-- The next input allows targeting in CSS-->
+      <input class="skillname-hidden" name="attr_skillname" type="hidden" />
+      <input class="skillname-grid" name="attr_skillname" type="text" />
       <div>
         <button class="popoverButton noPaddingButton" name="act_togglepopoverspellnote" type="action">&#128269;</button>
         <!--
@@ -986,24 +1032,6 @@ its value is used for css selection of its siblings.
           </div>
         </div>
       </div>
-    </fieldset>
-  </div>
-  <div class="innate section innate-spells-grid">
-    <input name="attr_innate_total_CP" type="hidden" value="0" />
-    <input name="attr_innate_total_single_CP" type="hidden" value="0" />
-    <div class="innate epic-table-header-grid">
-      <div class="skillname-grid">Name</div>
-      <div class="spellEP-grid">EP</div>
-      <div class="spellcasttime-grid">Cast Time</div>
-      <div class="spelltype-grid">Touch/ Ray/ Missile</div>
-      <div class="spellrange-grid">Range</div>
-      <div class="spelltarget-grid">Target</div>
-      <div class="spellduration-grid">Duration</div>
-      <div class="spellhasnote-grid">N</div>
-      <div class="skillCP-grid">CP</div>
-    </div>
-    <fieldset class="repeating_innate">
-      <input class="skillname-grid" name="attr_skillname" type="text" />
       <input class="spellEP-grid" name="attr_spellEP" type="text" />
       <input class="spellcasttime-grid" name="attr_spellcasttime" type="text" />
       <select class="spelltype-grid" name="attr_spelltype" type="text">
@@ -1015,32 +1043,6 @@ its value is used for css selection of its siblings.
       <input class="spellrange-grid" name="attr_spellrange" type="text" />
       <input class="spelltarget-grid" name="attr_spelltarget" type="text" />
       <input class="spellduration-grid" name="attr_spellduration" type="text" />
-      <div>
-        <button class="popoverButton noPaddingButton" name="act_togglepopoverspellnote" type="action">&#128269;</button>
-        <!--
-        The next input puts whether we have a note into the
-        value property, where CSS can see it
-        -->
-        <input class="popoverController" name="attr_visiblepopover" type="hidden" value="false" />
-        <div class="spellNotePopover popoverContainer">
-          <div class="popoverBackdrop">
-            <button name="act_closepopoverspellnotes" type="action">Close popover</button>
-          </div>
-          <div class="popover fixedPlacementPopover">
-            <!-- Buttons in a popover break stacking order, and pop out of the repeating stack.-->
-            <button class="closePopoverButton" name="act_closepopoverspellnotes" type="action">X</button>
-            <h2>
-              <span class="spell-name" name="attr_skillname"></span>
-            </h2>
-            <div class="small-spacer"></div>
-            <label>Name</label>
-            <input class="skillname-grid" name="attr_skillname" type="text" />
-            <label>Spell Notes</label>
-            <textarea class="spell-note" name="attr_spellnote" rows="6"></textarea>
-            <button name="act_closepopoverspellnotes" type="action">Close</button>
-          </div>
-        </div>
-      </div>
       <input class="skillCP-grid" name="attr_skillCP" type="number" />
     </fieldset>
   </div>

--- a/ui/basicTab/basicTab.pug
+++ b/ui/basicTab/basicTab.pug
@@ -2,7 +2,7 @@ include ../global/advantages.pug
 
 // Basic section 
 .basic.section.basic-tab
-  .advantages-and-feats.horizontal-flex
+  .advantages-and-feats
     // Character Attributes 
     .character-attributes
       .character-attributes.epic-table-header-grid

--- a/ui/basicTab/basicTab.scss
+++ b/ui/basicTab/basicTab.scss
@@ -42,7 +42,7 @@
   }
 
   .feats {
-    $feat-grid-template: getResponsiveGridWidths(24px, 160px, 48px);
+    $feat-grid-template: getResponsiveGridWidths(32px, 160px, 48px);
     @include epic-table-grid('feat', $feat-grid-template);
 
     input.featname-grid {

--- a/ui/buttons/buttons.scss
+++ b/ui/buttons/buttons.scss
@@ -12,9 +12,18 @@ button.actionRollButton {
   border-radius: 4px;
 }
 
+@mixin hovered-button($background-color: $button-roll-color-2) {
+  &:hover {
+    // Remove Roll20 default styles
+    background-image: unset;
+    background-color: $background-color;
+  }
+}
+
 @mixin roll-action-button {
   @include action-button;
   background-image: linear-gradient(90deg, $button-roll-color-1, $button-roll-color-2);
+  @include hovered-button();
 }
 
 /* Change the character for dice roll buttons to be
@@ -62,11 +71,13 @@ button.big-control.do-and-roll {
 .disable-do[value="1"]~.do {
   background-image: linear-gradient(90deg, #ddd, #ddd);
   pointer-events: none;
+  @include hovered-button();
 }
 
 .disable-do-and-roll[value="1"]~.do-and-roll {
   background-image: linear-gradient(90deg, #ddd, #ddd);
   pointer-events: none;
+  @include hovered-button();
 }
 
 
@@ -82,6 +93,7 @@ button.undo::before {
   background-image: linear-gradient(90deg, $button-undo-roll-color-1, $button-undo-roll-color-2);
   line-height: 1;
   padding: 1px 1px;
+  @include hovered-button($button-undo-roll-color-2);
 }
 
 button.undo {
@@ -94,6 +106,7 @@ button.reset-total {
   line-height: 1;
   padding: 2px;
   vertical-align: middle;
+  @include hovered-button();
 }
 
 button.convert-button {
@@ -102,4 +115,5 @@ button.convert-button {
   padding: 0px 2px 4px 2px;
   vertical-align: middle;
   font-size: 200%;
+  @include hovered-button();
 }

--- a/ui/components/gridTable/gridTable.scss
+++ b/ui/components/gridTable/gridTable.scss
@@ -24,6 +24,7 @@ $grid-column-gap: 2px;
   row-gap: 0;
   column-gap: $grid-column-gap;
   background: transparent;
+  word-break: break-word;
   input, input[type=number], textarea, select {
     width: 100% !important;
     margin-left: unset;

--- a/ui/components/gridTable/gridTable.scss
+++ b/ui/components/gridTable/gridTable.scss
@@ -10,7 +10,7 @@ $grid-column-gap: 2px;
   background: $primary-highlight-background-color;
   color: $primary-highlight-color;
   padding: $grid-padding;
-
+  word-break: break-word;
   > div {
     text-align: center;
     margin: auto;

--- a/ui/components/index.scss
+++ b/ui/components/index.scss
@@ -1,1 +1,2 @@
 @import './popover/popover.scss';
+@import './tooltip/tooltip.scss';

--- a/ui/components/tooltip/tooltip.scss
+++ b/ui/components/tooltip/tooltip.scss
@@ -1,0 +1,24 @@
+.epic-tooltip {
+  position: relative;
+  display: inline-block;
+
+  .epic-tooltip-text {
+    visibility: hidden;
+    max-width: 300px;
+    word-break: normal;
+    background-color: black;
+    color: #fff;
+    text-align: center;
+    border-radius: 4px;
+    padding: 4px;
+    /* Position the tooltip */
+    position: absolute;
+    z-index: 1;
+    top: 105%;
+    left: 0;
+  }
+
+  &:hover .epic-tooltip-text {
+    visibility: visible;
+  }
+}

--- a/ui/epicSkills/epicSkills.pug
+++ b/ui/epicSkills/epicSkills.pug
@@ -1,7 +1,7 @@
 // skill section 
 .skills.section.epic-skills-tab
-  .flex-stack.full-width
-    .center.bold Disciplines &amp; Skills
+  div
+    .bold Disciplines &amp; Skills
   .epic-skill-table
     input(name='attr_skill_total_TP' type='hidden' value='0')
     input(name='attr_skill_total_CP' type='hidden' value='0')

--- a/ui/epicSkills/epicSkills.scss
+++ b/ui/epicSkills/epicSkills.scss
@@ -3,15 +3,16 @@
 
 /* -------- Skills --------- */
 .epic-skills-tab {
+  max-width: 600px;
   $skill-grid-template: getResponsiveGridWidths(
     40px, // Discipline?
-    5fr, // Name
-    36px, // Ability
+    4fr, // Name
+    40px, // Ability
     24px, // TP
     24px, // CP
     1fr, // Exper
     2fr, // Attribute
-    1fr // Base
+    40px // Base
   );
   @include epic-table-grid('skill', $skill-grid-template);
 

--- a/ui/epicSkills/epicSkills.scss
+++ b/ui/epicSkills/epicSkills.scss
@@ -11,7 +11,7 @@
     24px, // TP
     24px, // CP
     1fr, // Exper
-    2fr, // Attribute
+    72px, // Attribute
     40px // Base
   );
   @include epic-table-grid('skill', $skill-grid-template);

--- a/ui/equipment/equipment.pug
+++ b/ui/equipment/equipment.pug
@@ -1,17 +1,17 @@
 // Equipment section 
 .equipment.section.equipment-tab
-  .horizontal-flex.flex-gap
+  .cash-and-equipment-summary
     div
-      .attribute-name.wideish.larger.inline.bold.right.middle Cash
+      .attribute-name.larger.inline.bold.right.middle Cash
       input.wide.center.bold.larger.value(name='attr_cash' type='number')
     div
       .attribute-name.larger.inline.bold.right.middle Equip Value
-      span.narrowish.center.bold.larger.value.middle(name='attr_equipment_total_value')
+      span.center.bold.larger.value.middle(name='attr_equipment_total_value')
     div
       .attribute-name.larger.inline.bold.right.middle Equip Weight
-      span.narrowish.center.bold.larger.value.middle(name='attr_equipment_total_weight')
+      span.center.bold.larger.value.middle(name='attr_equipment_total_weight')
   = '\n'
-  .spacer
+  .small-spacer
   .armor-table
     .armor-shield-weapons-tables
       .epic-table-header-grid.armor

--- a/ui/equipment/equipment.scss
+++ b/ui/equipment/equipment.scss
@@ -2,6 +2,11 @@
 
 /* -------- Equipment --------- */
 .equipment-tab {
+  .cash-and-equipment-summary {
+    display: flex;
+    gap: 16px;
+  }
+
   $armor-grid-template: getResponsiveGridWidths(5fr, 1fr, 1fr, 1fr, 5fr);
   @include epic-table-grid('armor', $armor-grid-template);
 

--- a/ui/global/global.scss
+++ b/ui/global/global.scss
@@ -11,10 +11,6 @@
   }
 }
 
-.invisible {
-  display: none;
-}
-
 .inline {
   display: inline-block;
 }
@@ -33,10 +29,6 @@
 
 .middle {
   vertical-align: middle;
-}
-
-.full-width {
-  width: 100%;
 }
 
 .narrow.narrow.narrow {
@@ -63,14 +55,9 @@
   width: 90px;
 }
 
-.wider.wider.wider {
-  width: 150px;
-}
-
 .narrow-spacing {
   line-height: 1;
 }
-
 
 .spacer {
   height: 16px;
@@ -82,26 +69,6 @@
 
 .inlne-spacer {
   width: 8px;
-}
-
-.horizontal-flex {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-}
-
-.flex-gap {
-  gap: 16px;
-}
-
-.horizontal-flex-center {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-}
-
-.align-center.align-center.align-center {
-  align-items: center;
 }
 
 .flexing {
@@ -135,10 +102,6 @@
 }
 
 .bold {
-  font-weight: bold;
-}
-
-.number.ability {
   font-weight: bold;
 }
 

--- a/ui/overviewTab/overviewTab.pug
+++ b/ui/overviewTab/overviewTab.pug
@@ -2,7 +2,7 @@ include ../global/advantages.pug
 
 // Overview section 
 .overview.section.overview-tab
-  .horizontal-flex
+  .tables-container
     // Advantages 
     .advantage-overview.no-add-or-modify-buttons
       .advantage.epic-table-header-grid

--- a/ui/overviewTab/overviewTab.scss
+++ b/ui/overviewTab/overviewTab.scss
@@ -9,7 +9,7 @@
 
 /* ---------- Overview tab ------------- */
 .overview-tab {
-  > .horizontal-flex {
+  .tables-container {
     display: flex;
     gap: 16px;
   }

--- a/ui/overviewTab/overviewTab.scss
+++ b/ui/overviewTab/overviewTab.scss
@@ -13,7 +13,7 @@
     display: flex;
     gap: 16px;
   }
-  
+
   .advantage-overview {
     $advantage-grid-template: getResponsiveGridWidths(128px);
     @include epic-table-grid('advantage', $advantage-grid-template);
@@ -53,7 +53,7 @@
 
   /* ------------ Feat Overview -------------- */
   .feat-overview {
-    $feat-grid-template: getResponsiveGridWidths(24px, 96px);
+    $feat-grid-template: getResponsiveGridWidths(32px, 96px);
     @include epic-table-grid('feat', $feat-grid-template);
 
     >div[data-groupname] {
@@ -79,7 +79,7 @@
       display: none;
     }
 
-    $skills-table-grid-template: getResponsiveGridWidths(96px, 32px, 32px, 24px);
+    $skills-table-grid-template: getResponsiveGridWidths(96px, 36px, 36px, 24px);
     @include epic-table-grid('skills-table', $skills-table-grid-template);
     .epic-table-header-grid {
       .skillability {
@@ -112,7 +112,7 @@
   /* ------------ Weapons Overview -------------- */
   .weapons-overview {
     width: 50%;
-    $weapons-table-grid-template: getResponsiveGridWidths(128px, 48px, 60px, 32px);
+    $weapons-table-grid-template: getResponsiveGridWidths(128px, 48px, 60px, 56px);
     @include epic-table-grid('weapons-table', $weapons-table-grid-template);
     $weapons-equipmentnotes-table-grid-template: getResponsiveGridWidths(1fr);
     @include epic-table-grid('weapons-equipmentnotes-table', $weapons-equipmentnotes-table-grid-template);

--- a/ui/spells/spells.pug
+++ b/ui/spells/spells.pug
@@ -127,7 +127,8 @@
     input(name='attr_innate_total_CP' type='hidden' value='0')
     input(name='attr_innate_total_single_CP' type='hidden' value='0')
     .innate.epic-table-header-grid
-      .skill-innatesphere-grid Sphere?
+      .skill-innatesphere-grid.epic-tooltip Sph
+        span.epic-tooltip-text Spell Sphere
       .skillname-grid Name
       .spellhasnote-grid N
       .spellEP-grid EP

--- a/ui/spells/spells.pug
+++ b/ui/spells/spells.pug
@@ -127,6 +127,7 @@
     input(name='attr_innate_total_CP' type='hidden' value='0')
     input(name='attr_innate_total_single_CP' type='hidden' value='0')
     .innate.epic-table-header-grid
+      .skill-innatesphere-grid Sphere?
       .skillname-grid Name
       .spellhasnote-grid N
       .spellEP-grid EP
@@ -137,8 +138,11 @@
       .spellduration-grid Damage/ Duration
       .skillCP-grid CP
     fieldset.repeating_innate
+      select.skill-innatesphere-grid(name='attr_skillinnatesphere')
+        option(value=' ')
+        option(value='S') S
       // The next input allows targeting in CSS
-      input.skillname-hidden(name='attr_skillname' type='hidden')
+      input.innatesphere-hidden(name='attr_skillinnatesphere' type='hidden')
       input.skillname-grid(name='attr_skillname' type='text')
       include ./spellsNotesPopover.pug
       input.spellEP-grid(name='attr_spellEP' type='text')

--- a/ui/spells/spells.pug
+++ b/ui/spells/spells.pug
@@ -103,15 +103,16 @@
     input(name='attr_divine_total_single_CP' type='hidden' value='0')
     .divine.epic-table-header-grid
       .skillname-grid Name
+      .spellhasnote-grid N
       .spellEP-grid EP
       .spellcasttime-grid Cast Time
       .spelltype-grid Touch/ Ray/ Missile
       .spellrange-grid Range
       .spelltarget-grid Target
       .spellduration-grid Damage/ Duration
-      .spellhasnote-grid N
     fieldset.repeating_divine
       input.skillname-grid(name='attr_skillname' type='text')
+      include ./spellsNotesPopover.pug
       input.spellEP-grid(name='attr_spellEP' type='number')
       input.spellcasttime-grid(name='attr_spellcasttime' type='text')
       select.spelltype-grid(name='attr_spelltype' type='text')
@@ -122,22 +123,24 @@
       input.spellrange-grid(name='attr_spellrange' type='text')
       input.spelltarget-grid(name='attr_spelltarget' type='text')
       input.spellduration-grid(name='attr_spellduration' type='text')
-      include ./spellsNotesPopover.pug
   .innate.section.innate-spells-grid
     input(name='attr_innate_total_CP' type='hidden' value='0')
     input(name='attr_innate_total_single_CP' type='hidden' value='0')
     .innate.epic-table-header-grid
       .skillname-grid Name
+      .spellhasnote-grid N
       .spellEP-grid EP
       .spellcasttime-grid Cast Time
       .spelltype-grid Touch/ Ray/ Missile
       .spellrange-grid Range
       .spelltarget-grid Target
-      .spellduration-grid Duration
-      .spellhasnote-grid N
+      .spellduration-grid Damage/ Duration
       .skillCP-grid CP
     fieldset.repeating_innate
+      // The next input allows targeting in CSS
+      input.skillname-hidden(name='attr_skillname' type='hidden')
       input.skillname-grid(name='attr_skillname' type='text')
+      include ./spellsNotesPopover.pug
       input.spellEP-grid(name='attr_spellEP' type='text')
       input.spellcasttime-grid(name='attr_spellcasttime' type='text')
       select.spelltype-grid(name='attr_spelltype' type='text')
@@ -148,5 +151,4 @@
       input.spellrange-grid(name='attr_spellrange' type='text')
       input.spelltarget-grid(name='attr_spelltarget' type='text')
       input.spellduration-grid(name='attr_spellduration' type='text')
-      include ./spellsNotesPopover.pug
       input.skillCP-grid(name='attr_skillCP' type='number')

--- a/ui/spells/spells.pug
+++ b/ui/spells/spells.pug
@@ -1,5 +1,5 @@
 // Spells section 
-.spells.section.horizontal-flex
+.spells.section
   //
     This input's value names the currently selected tab.
     its value is used for css selection of the tab content.
@@ -22,13 +22,13 @@
     .spell-header-action-area
       .label.wide.larger Spell Touch
       input(name='attr_spell_touch' type='hidden')
-      span.center.narrowish.bold.larger.middle(name='attr_spell_touch')
+      span.center.bold.larger.middle(name='attr_spell_touch')
       button(type='roll' value='!EPRoll @{spell_touch} Touches with Spell: @{spell_touch}')
       = '\n'
       | &emsp;
       .label.wide.larger Aim Spell
       input(name='attr_aim_spell' type='hidden')
-      span.center.narrowish.bold.larger.middle(name='attr_aim_spell')
+      span.center.bold.larger.middle(name='attr_aim_spell')
       button(type='roll' value='!EPRoll @{aim_spell} Aims Spell: @{aim_spell}')
   // Arcane spells 
   .arcane.section

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -19,7 +19,9 @@
   display: block;
 }
 
+$notes-popover-width: 16px;
 .spell-tabs {
+
   border-bottom: solid black 1px;
   margin-bottom: 6px;
   display: flex;
@@ -46,15 +48,15 @@
     40px, // Discipline?
     4fr, // Name
     32px, // Ability
-    1fr, // Mod
+    40px, // Mod
     0.5fr, // (Dice)
     40px, // EP
     1fr, // Cast Time
-    88px, // Touch/ Ray/ Missile
-    40px, // Range
-    40px, // Target
+    72px, // Touch/ Ray/ Missile
+    1.5fr, // Range
+    2fr, // Target
     1.5fr, // Damage/ Duration
-    24px, // N(otes)
+    $notes-popover-width, // N(otes)
     24px, // TP
     24px, // CP
     40px, // Exper.
@@ -71,6 +73,12 @@
     }
   }
 
+  .skillname-hidden[value|="----"]~.skillname-grid {
+    // If the name starts with dashes, style the name
+    font-weight: bold;
+    text-align: center;
+  }
+
   .isdiscipline-grid[value="1"]~.skillname-grid {
     font-weight: bold;
     text-align: center;
@@ -83,10 +91,10 @@
     white-space: nowrap;
   }
 
-  $divine-grid-template: getResponsiveGridWidths(6fr, 1fr, 1fr, 2fr, 1fr, 1fr, 2fr, 0.5fr);
+  $divine-grid-template: getResponsiveGridWidths(6fr, $notes-popover-width, 1fr, 1fr, 2fr, 1fr, 1fr, 2fr);
   @include epic-table-grid('divine', $divine-grid-template);
 
-  $innate-grid-template: getResponsiveGridWidths(6fr, 1fr, 2fr, 3fr, 2fr, 3fr, 2fr, 0.5fr, 1fr);
+  $innate-grid-template: getResponsiveGridWidths(6fr, $notes-popover-width, 1fr, 2fr, 2fr, 2fr, 3fr, 2fr, 32px);
   @include epic-table-grid('innate', $innate-grid-template);
 
   @include grid-table-tp-cp-columns();

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -39,6 +39,8 @@ $notes-popover-width: 16px;
 /* Avoid space between items in the row */
 .spells {
   .spell-header-action-area {
+    display: flex;
+    gap: 8px;
     label, .label {
       color: black;
     }

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -52,7 +52,7 @@ $notes-popover-width: 16px;
     0.5fr, // (Dice)
     40px, // EP
     1fr, // Cast Time
-    72px, // Touch/ Ray/ Missile
+    80px, // Touch/ Ray/ Missile - 80px for two rows not three
     1.5fr, // Range
     2fr, // Target
     1.5fr, // Damage/ Duration

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -75,12 +75,6 @@ $notes-popover-width: 16px;
     }
   }
 
-  .skillname-hidden[value|="----"]~.skillname-grid {
-    // If the name starts with dashes, style the name
-    font-weight: bold;
-    text-align: center;
-  }
-
   .isdiscipline-grid[value="1"]~.skillname-grid {
     font-weight: bold;
     text-align: center;
@@ -96,8 +90,32 @@ $notes-popover-width: 16px;
   $divine-grid-template: getResponsiveGridWidths(6fr, $notes-popover-width, 1fr, 1fr, 2fr, 1fr, 1fr, 2fr);
   @include epic-table-grid('divine', $divine-grid-template);
 
-  $innate-grid-template: getResponsiveGridWidths(6fr, $notes-popover-width, 1fr, 2fr, 2fr, 2fr, 3fr, 2fr, 32px);
+  $innate-grid-template: getResponsiveGridWidths(
+    40px, // Sphere?
+    6fr, // Name
+    $notes-popover-width, // Note Popover
+    32px, //EP
+    2fr, // Cast Time
+    2fr, // Touch/Ray/Missle
+    2fr, // Range
+    3fr, // Target
+    2fr, // Damage/Duration
+    32px, // CP
+  );
   @include epic-table-grid('innate', $innate-grid-template);
+
+  .innatesphere-hidden[value|="S"]{
+    ~.skillname-grid {
+      // If the row is a sphere, style it
+      font-weight: bold;
+      text-align: center;
+    }
+    ~:not(.skillname-grid) {
+      opacity: 0;
+      cursor: default;
+      pointer-events: none;
+    }
+  }
 
   @include grid-table-tp-cp-columns();
 

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -45,6 +45,7 @@ $notes-popover-width: 16px;
       color: black;
     }
   }
+  @import './spellsNotesPopover.scss';
 
   $arcane-grid-template: getResponsiveGridWidths(
     40px, // Discipline?

--- a/ui/spells/spellsNotesPopover.pug
+++ b/ui/spells/spellsNotesPopover.pug
@@ -1,6 +1,6 @@
-div
-  button.popoverButton.noPaddingButton(name='act_togglepopoverspellnote' type='action')
-    | &#128269;
+.spellNotesPopover
+  input.spellnote-hidden(name='attr_spellnote' type='hidden')
+  button.popoverButton(name='act_togglepopoverspellnote' type='action')
   //
     The next input puts whether we have a note into the
     value property, where CSS can see it

--- a/ui/spells/spellsNotesPopover.scss
+++ b/ui/spells/spellsNotesPopover.scss
@@ -1,0 +1,30 @@
+.spellNotesPopover {
+  button.popoverButton {
+    // See https://wiki.roll20.net/Roll20_UI_Icons
+    font-family: Pictos;
+    font-size: 12px;
+    line-height: 18px;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    border-radius: 100%;
+    padding: 0 !important;
+    color: $paper-color;
+    background-color: $primary-highlight-background-color;
+  }
+  .spellnote-hidden[value]{
+    ~button.popoverButton::after {
+      // See https://wiki.roll20.net/Roll20_UI_Icons
+      content: 's'; // Magnifying glass
+      color: #80ffff;
+    }
+  }
+  .spellnote-hidden:not([value]), .spellnote-hidden[value=""]{ 
+    ~button.popoverButton::after {
+      // See https://wiki.roll20.net/Roll20_UI_Icons
+      content: '&'; // Plus sign
+      color: #efcb83;
+    }
+  }
+}

--- a/ui/topSection/topSection.pug
+++ b/ui/topSection/topSection.pug
@@ -39,7 +39,7 @@
     //
       These are read only, except in the basic tab,
       where they can be changed, and their CP cost is shown
-    .horizontal-flex-center
+    .attribute-row
       input.attributecontrol.cpcontrol(name='attr_chosentab' type='hidden' value='basic')
       .attribute-name.big IQ
       = '\n'
@@ -118,7 +118,7 @@
         .section.weightPenalties.popoverContainer
           .popoverBackdrop
             button(name='act_popover_weightPenalties' type='action') Close popover
-          .flex-stack.align-center.popover
+          .popover
             button.closePopoverButton(name='act_popover_weightPenalties' type='action') X
             .center.wideish.bold Weight Penalties
             .weight-penalty-table.flex-stack

--- a/ui/topSection/topSection.scss
+++ b/ui/topSection/topSection.scss
@@ -6,6 +6,10 @@
   border-bottom: solid black 1px;
   margin-bottom: 6px;
   background: linear-gradient(to top, $paper-gradient-color 0%, transparent 100%);
+  .attribute-row {
+    display: flex;
+    align-items: center;
+  }
 }
 
 @include popover-control('weightPenalties');


### PR DESCRIPTION
Fix Overview tab, Skill mod column is too narrow for double digits. #62

Fix Consider making grid columns use `word-break: break-word` #61

Fix Small formatting issues #60

* Innate spells, update column title to `Damage/Duration`.
* For arcane spells, adjust columns:
  * the mod column should not stretc
  * the target column should stretch.
  * Also, adjusted range and target to be stretch.
* Fix button hover styles.
* Move Notes popover icon to be next to name
* For innate, make name be bold and centered when starting with dashes.


## Screenies

| Old | New |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/5629800/212509513-ce183fb8-a94e-441e-bfcb-f050e6e2cf4c.png) | ![image](https://user-images.githubusercontent.com/5629800/212510259-7295f506-3298-4801-97d1-87b24c5f49d3.png) |

Others:
![image](https://user-images.githubusercontent.com/5629800/212770850-56cf3701-0e7a-4171-bfc1-b6777d0758bd.png)

![image](https://user-images.githubusercontent.com/5629800/212770830-12b7bd72-8563-40ad-9b16-212b1be062f9.png)
![image](https://user-images.githubusercontent.com/5629800/212779276-c2fd34f5-04c7-40c0-a7b5-151e957c75b9.png)

Button examples for spells with or without notes.
![image](https://user-images.githubusercontent.com/5629800/212784590-6192addb-f226-43f5-8b3a-94b74736e4cb.png)
