### PR TITLE
Refactor defense top section to fix misalingment, add table row borders

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -2254,15 +2254,6 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 11;
 }
-.spells .innatesphere-hidden[value|=S] ~ .skillname-grid {
-  font-weight: bold;
-  text-align: center;
-}
-.spells .innatesphere-hidden[value|=S] ~ :not(.skillname-grid) {
-  opacity: 0;
-  cursor: default;
-  pointer-events: none;
-}
 .spells div[data-groupname=repeating_innate] > div input, .spells div[data-groupname=repeating_innate] > div select, .spells div[data-groupname=repeating_innate] > div textarea,
 .spells div[data-epic-table-name=innate] input,
 .spells div[data-epic-table-name=innate] select,
@@ -2272,6 +2263,15 @@ radio > span.checked {
 .spells div[data-groupname=repeating_innate] > div + div,
 .spells div[data-epic-table-name=innate] + div[data-epic-table-name=innate] {
   border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
+.spells .innatesphere-hidden[value|=S] ~ .skillname-grid {
+  font-weight: bold;
+  text-align: center;
+}
+.spells .innatesphere-hidden[value|=S] ~ :not(.skillname-grid) {
+  opacity: 0;
+  cursor: default;
+  pointer-events: none;
 }
 .spells .skillTP-grid, .spells .TP-grid {
   color: #267200;

--- a/bin/main.css
+++ b/bin/main.css
@@ -580,13 +580,18 @@ radio > span.checked {
   display: flex;
   align-items: center;
 }
-
-.sectioncontrol[value=weightPenalties] ~ div.popoverContainer.weightPenalties,
-input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties {
+.top-section .tab-holder {
+  margin-top: 4px;
+}
+.top-section .sectioncontrol[value=weightPenalties] ~ div.popoverContainer.weightPenalties,
+.top-section input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties {
   display: inline;
 }
-.sectioncontrol[value=weightPenalties] ~ div.popoverContainer.weightPenalties .popover,
-input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popover {
+.top-section .sectioncontrol[value=weightPenalties] ~ div.popoverContainer.weightPenalties .popover,
+.top-section input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popover {
+  display: block;
+}
+.top-section .defenseBlock {
   display: block;
 }
 

--- a/bin/main.css
+++ b/bin/main.css
@@ -377,7 +377,7 @@ button.convert-button:hover {
 }
 
 .children-separated > :not(:first-child) {
-  border: solid #b56632;
+  border: solid rgba(181, 102, 50, 0.7);
   border-width: 1px 0px 0px 0px;
 }
 
@@ -591,8 +591,83 @@ radio > span.checked {
 .top-section input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popover {
   display: block;
 }
-.top-section .defenseBlock {
-  display: block;
+.top-section .defense-block .epic-table-header-grid.defenses {
+  display: grid;
+  grid-template-columns: minmax(0, 50px) minmax(0, 50px) minmax(0, 50px);
+  column-gap: 2px;
+  background: #b56632;
+  color: #fff;
+  padding: 0 2px;
+  margin-bottom: 2px;
+  word-break: break-word;
+}
+.top-section .defense-block .epic-table-header-grid.defenses > div {
+  text-align: center;
+  margin: auto;
+  font-weight: bold;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses] > div,
+.top-section .defense-block div[data-epic-table-name=defenses] {
+  display: grid;
+  grid-template-columns: minmax(0, 50px) minmax(0, 50px) minmax(0, 50px);
+  row-gap: 0;
+  column-gap: 2px;
+  background: transparent;
+  word-break: break-word;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses] > div input, .top-section .defense-block div[data-groupname=repeating_defenses] > div input[type=number], .top-section .defense-block div[data-groupname=repeating_defenses] > div textarea, .top-section .defense-block div[data-groupname=repeating_defenses] > div select,
+.top-section .defense-block div[data-epic-table-name=defenses] input,
+.top-section .defense-block div[data-epic-table-name=defenses] input[type=number],
+.top-section .defense-block div[data-epic-table-name=defenses] textarea,
+.top-section .defense-block div[data-epic-table-name=defenses] select {
+  width: 100% !important;
+  margin-left: unset;
+  height: auto;
+  background-color: #faf2ec;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses] > div input[type=text],
+.top-section .defense-block div[data-epic-table-name=defenses] input[type=text] {
+  text-align: left;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses] > div input, .top-section .defense-block div[data-groupname=repeating_defenses] > div select,
+.top-section .defense-block div[data-epic-table-name=defenses] input,
+.top-section .defense-block div[data-epic-table-name=defenses] select {
+  white-space: nowrap;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses] > div span,
+.top-section .defense-block div[data-epic-table-name=defenses] span {
+  text-align: center;
+  margin: auto 0;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses] > div button, .top-section .defense-block div[data-groupname=repeating_defenses] > div button[type=roll],
+.top-section .defense-block div[data-epic-table-name=defenses] button,
+.top-section .defense-block div[data-epic-table-name=defenses] button[type=roll] {
+  margin: 0;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses] > div .epic-table-row.conditional-one,
+.top-section .defense-block div[data-epic-table-name=defenses] .epic-table-row.conditional-one {
+  display: grid;
+  grid-column-start: 1;
+  grid-column-end: 4;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses] > div input, .top-section .defense-block div[data-groupname=repeating_defenses] > div select, .top-section .defense-block div[data-groupname=repeating_defenses] > div textarea,
+.top-section .defense-block div[data-epic-table-name=defenses] input,
+.top-section .defense-block div[data-epic-table-name=defenses] select,
+.top-section .defense-block div[data-epic-table-name=defenses] textarea {
+  border: unset;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses] > div + div,
+.top-section .defense-block div[data-epic-table-name=defenses] + div[data-epic-table-name=defenses] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
+.top-section .defense-block .table-label {
+  text-align: right;
+  margin: auto;
+  margin-right: 2px;
+  font-weight: bold;
+}
+.top-section .defense-block input[type=number] {
+  text-align: right;
 }
 
 /* ------ generic conditional appearance ------ */
@@ -708,7 +783,7 @@ radio > span.checked {
 }
 
 .weight-penalty-table > div:not(:last-child):not(.table-header) {
-  border-bottom: solid #b56632 1px;
+  border-bottom: solid rgba(181, 102, 50, 0.7) 1px;
 }
 
 .weight-penalty-table > div > :nth-child(2) {
@@ -742,7 +817,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .overview-tab .advantage-overview .epic-table-header-grid.advantage > div {
@@ -800,7 +876,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .overview-tab .advantage-overview .epic-table-header-grid.extraadvantage > div {
@@ -861,7 +938,7 @@ radio > span.checked {
   display: flex;
   justify-content: space-between;
   width: 100%;
-  border: solid #b56632;
+  border: solid rgba(181, 102, 50, 0.7);
   border-width: 0px 0px 1px 0px;
   padding-top: 2px;
   padding-bottom: 2px;
@@ -872,7 +949,7 @@ radio > span.checked {
   text-align: left !important;
 }
 .overview-tab .advantage-overview .extraadvantage-row {
-  border: solid #b56632;
+  border: solid rgba(181, 102, 50, 0.7);
   border-width: 0px 0px 1px 0px;
   padding-top: 2px;
   padding-bottom: 2px;
@@ -889,7 +966,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .overview-tab .feat-overview .epic-table-header-grid.feat > div {
@@ -942,7 +1020,7 @@ radio > span.checked {
   grid-column-end: 3;
 }
 .overview-tab .feat-overview > div[data-groupname] > div {
-  border: solid #b56632;
+  border: solid rgba(181, 102, 50, 0.7);
   border-width: 0px 0px 1px 0px;
   padding-top: 2px;
   padding-bottom: 2px;
@@ -963,7 +1041,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .overview-tab .skills-overview .epic-table-header-grid.skills-table > div {
@@ -1019,7 +1098,7 @@ radio > span.checked {
   font-weight: normal !important;
 }
 .overview-tab .skills-overview > div[data-groupname] .skill-overview-row-container {
-  border: solid #b56632;
+  border: solid rgba(181, 102, 50, 0.7);
   border-width: 0px 0px 1px 0px;
   padding-top: 2px;
   padding-bottom: 2px;
@@ -1049,7 +1128,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .overview-tab .weapons-overview .epic-table-header-grid.weapons-table > div {
@@ -1107,7 +1187,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .overview-tab .weapons-overview .epic-table-header-grid.weapons-equipmentnotes-table > div {
@@ -1163,7 +1244,7 @@ radio > span.checked {
   display: none;
 }
 .overview-tab .weapons-overview > div[data-groupname] .weapons-table-row {
-  border: solid #b56632;
+  border: solid rgba(181, 102, 50, 0.7);
   border-width: 0px 0px 1px 0px;
   padding-top: 2px;
   padding-bottom: 2px;
@@ -1200,7 +1281,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .basic-tab .character-attributes .epic-table-header-grid.character-attributes > div {
@@ -1252,6 +1334,16 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 3;
 }
+.basic-tab .character-attributes div[data-groupname=repeating_character-attributes] > div input, .basic-tab .character-attributes div[data-groupname=repeating_character-attributes] > div select, .basic-tab .character-attributes div[data-groupname=repeating_character-attributes] > div textarea,
+.basic-tab .character-attributes div[data-epic-table-name=character-attributes] input,
+.basic-tab .character-attributes div[data-epic-table-name=character-attributes] select,
+.basic-tab .character-attributes div[data-epic-table-name=character-attributes] textarea {
+  border: unset;
+}
+.basic-tab .character-attributes div[data-groupname=repeating_character-attributes] > div + div,
+.basic-tab .character-attributes div[data-epic-table-name=character-attributes] + div[data-epic-table-name=character-attributes] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .basic-tab .character-attributes .character-attributes-table .character-attributes-name-grid {
   text-align: right;
   font-weight: bold;
@@ -1266,7 +1358,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .basic-tab .advantages .epic-table-header-grid.advantage > div {
@@ -1318,13 +1411,24 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 4;
 }
+.basic-tab .advantages div[data-groupname=repeating_advantage] > div input, .basic-tab .advantages div[data-groupname=repeating_advantage] > div select, .basic-tab .advantages div[data-groupname=repeating_advantage] > div textarea,
+.basic-tab .advantages div[data-epic-table-name=advantage] input,
+.basic-tab .advantages div[data-epic-table-name=advantage] select,
+.basic-tab .advantages div[data-epic-table-name=advantage] textarea {
+  border: unset;
+}
+.basic-tab .advantages div[data-groupname=repeating_advantage] > div + div,
+.basic-tab .advantages div[data-epic-table-name=advantage] + div[data-epic-table-name=advantage] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .basic-tab .advantages .epic-table-header-grid.extraadvantage {
   display: grid;
   grid-template-columns: minmax(0, 160px) minmax(0, 48px) minmax(0, 32px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .basic-tab .advantages .epic-table-header-grid.extraadvantage > div {
@@ -1376,6 +1480,16 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 4;
 }
+.basic-tab .advantages div[data-groupname=repeating_extraadvantage] > div input, .basic-tab .advantages div[data-groupname=repeating_extraadvantage] > div select, .basic-tab .advantages div[data-groupname=repeating_extraadvantage] > div textarea,
+.basic-tab .advantages div[data-epic-table-name=extraadvantage] input,
+.basic-tab .advantages div[data-epic-table-name=extraadvantage] select,
+.basic-tab .advantages div[data-epic-table-name=extraadvantage] textarea {
+  border: unset;
+}
+.basic-tab .advantages div[data-groupname=repeating_extraadvantage] > div + div,
+.basic-tab .advantages div[data-epic-table-name=extraadvantage] + div[data-epic-table-name=extraadvantage] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .basic-tab .advantages .advantage-grid, .basic-tab .advantages .extraadvantagename-grid {
   text-align: right !important;
   font-weight: bold;
@@ -1405,7 +1519,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .basic-tab .feats .epic-table-header-grid.feat > div {
@@ -1457,6 +1572,16 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 4;
 }
+.basic-tab .feats div[data-groupname=repeating_feat] > div input, .basic-tab .feats div[data-groupname=repeating_feat] > div select, .basic-tab .feats div[data-groupname=repeating_feat] > div textarea,
+.basic-tab .feats div[data-epic-table-name=feat] input,
+.basic-tab .feats div[data-epic-table-name=feat] select,
+.basic-tab .feats div[data-epic-table-name=feat] textarea {
+  border: unset;
+}
+.basic-tab .feats div[data-groupname=repeating_feat] > div + div,
+.basic-tab .feats div[data-epic-table-name=feat] + div[data-epic-table-name=feat] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .basic-tab .feats input.featname-grid {
   text-align: right !important;
 }
@@ -1485,7 +1610,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .epic-skills-tab .epic-table-header-grid.skill > div {
@@ -1537,6 +1663,16 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 9;
 }
+.epic-skills-tab div[data-groupname=repeating_skill] > div input, .epic-skills-tab div[data-groupname=repeating_skill] > div select, .epic-skills-tab div[data-groupname=repeating_skill] > div textarea,
+.epic-skills-tab div[data-epic-table-name=skill] input,
+.epic-skills-tab div[data-epic-table-name=skill] select,
+.epic-skills-tab div[data-epic-table-name=skill] textarea {
+  border: unset;
+}
+.epic-skills-tab div[data-groupname=repeating_skill] > div + div,
+.epic-skills-tab div[data-epic-table-name=skill] + div[data-epic-table-name=skill] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillability-grid, .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillattribute-grid, .epic-skills-tab .isdiscipline-grid[value="1"] ~ .skillbase-grid {
   opacity: 0;
   cursor: default;
@@ -1575,7 +1711,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .equipment-tab .epic-table-header-grid.armor > div {
@@ -1627,13 +1764,24 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 6;
 }
+.equipment-tab div[data-groupname=repeating_armor] > div input, .equipment-tab div[data-groupname=repeating_armor] > div select, .equipment-tab div[data-groupname=repeating_armor] > div textarea,
+.equipment-tab div[data-epic-table-name=armor] input,
+.equipment-tab div[data-epic-table-name=armor] select,
+.equipment-tab div[data-epic-table-name=armor] textarea {
+  border: unset;
+}
+.equipment-tab div[data-groupname=repeating_armor] > div + div,
+.equipment-tab div[data-epic-table-name=armor] + div[data-epic-table-name=armor] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .equipment-tab .epic-table-header-grid.shield {
   display: grid;
   grid-template-columns: minmax(0, 5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 5fr);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .equipment-tab .epic-table-header-grid.shield > div {
@@ -1685,13 +1833,24 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 7;
 }
+.equipment-tab div[data-groupname=repeating_shield] > div input, .equipment-tab div[data-groupname=repeating_shield] > div select, .equipment-tab div[data-groupname=repeating_shield] > div textarea,
+.equipment-tab div[data-epic-table-name=shield] input,
+.equipment-tab div[data-epic-table-name=shield] select,
+.equipment-tab div[data-epic-table-name=shield] textarea {
+  border: unset;
+}
+.equipment-tab div[data-groupname=repeating_shield] > div + div,
+.equipment-tab div[data-epic-table-name=shield] + div[data-epic-table-name=shield] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .equipment-tab .epic-table-header-grid.weapon {
   display: grid;
   grid-template-columns: minmax(0, 5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 5fr);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .equipment-tab .epic-table-header-grid.weapon > div {
@@ -1743,13 +1902,24 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 8;
 }
+.equipment-tab div[data-groupname=repeating_weapon] > div input, .equipment-tab div[data-groupname=repeating_weapon] > div select, .equipment-tab div[data-groupname=repeating_weapon] > div textarea,
+.equipment-tab div[data-epic-table-name=weapon] input,
+.equipment-tab div[data-epic-table-name=weapon] select,
+.equipment-tab div[data-epic-table-name=weapon] textarea {
+  border: unset;
+}
+.equipment-tab div[data-groupname=repeating_weapon] > div + div,
+.equipment-tab div[data-epic-table-name=weapon] + div[data-epic-table-name=weapon] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .equipment-tab .epic-table-header-grid.item {
   display: grid;
   grid-template-columns: minmax(0, 5fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 5fr);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .equipment-tab .epic-table-header-grid.item > div {
@@ -1800,6 +1970,16 @@ radio > span.checked {
   display: grid;
   grid-column-start: 1;
   grid-column-end: 6;
+}
+.equipment-tab div[data-groupname=repeating_item] > div input, .equipment-tab div[data-groupname=repeating_item] > div select, .equipment-tab div[data-groupname=repeating_item] > div textarea,
+.equipment-tab div[data-epic-table-name=item] input,
+.equipment-tab div[data-epic-table-name=item] select,
+.equipment-tab div[data-epic-table-name=item] textarea {
+  border: unset;
+}
+.equipment-tab div[data-groupname=repeating_item] > div + div,
+.equipment-tab div[data-epic-table-name=item] + div[data-epic-table-name=item] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
 }
 
 /* ------------- Spells ------------*/
@@ -1868,7 +2048,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .spells .epic-table-header-grid.arcane > div {
@@ -1920,6 +2101,16 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 18;
 }
+.spells div[data-groupname=repeating_arcane] > div input, .spells div[data-groupname=repeating_arcane] > div select, .spells div[data-groupname=repeating_arcane] > div textarea,
+.spells div[data-epic-table-name=arcane] input,
+.spells div[data-epic-table-name=arcane] select,
+.spells div[data-epic-table-name=arcane] textarea {
+  border: unset;
+}
+.spells div[data-groupname=repeating_arcane] > div + div,
+.spells div[data-epic-table-name=arcane] + div[data-epic-table-name=arcane] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .spells .isdiscipline-grid[value="1"] ~ :not(.skillname-grid, .skillTP-grid, .skillexpertise-grid) {
   opacity: 0;
   cursor: default;
@@ -1941,7 +2132,8 @@ radio > span.checked {
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .spells .epic-table-header-grid.divine > div {
@@ -1993,13 +2185,24 @@ radio > span.checked {
   grid-column-start: 1;
   grid-column-end: 9;
 }
+.spells div[data-groupname=repeating_divine] > div input, .spells div[data-groupname=repeating_divine] > div select, .spells div[data-groupname=repeating_divine] > div textarea,
+.spells div[data-epic-table-name=divine] input,
+.spells div[data-epic-table-name=divine] select,
+.spells div[data-epic-table-name=divine] textarea {
+  border: unset;
+}
+.spells div[data-groupname=repeating_divine] > div + div,
+.spells div[data-epic-table-name=divine] + div[data-epic-table-name=divine] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
 .spells .epic-table-header-grid.innate {
   display: grid;
   grid-template-columns: minmax(0, 40px) minmax(0, 6fr) minmax(0, 16px) minmax(0, 32px) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
-  padding: 2px;
+  padding: 0 2px;
+  margin-bottom: 2px;
   word-break: break-word;
 }
 .spells .epic-table-header-grid.innate > div {
@@ -2059,6 +2262,16 @@ radio > span.checked {
   opacity: 0;
   cursor: default;
   pointer-events: none;
+}
+.spells div[data-groupname=repeating_innate] > div input, .spells div[data-groupname=repeating_innate] > div select, .spells div[data-groupname=repeating_innate] > div textarea,
+.spells div[data-epic-table-name=innate] input,
+.spells div[data-epic-table-name=innate] select,
+.spells div[data-epic-table-name=innate] textarea {
+  border: unset;
+}
+.spells div[data-groupname=repeating_innate] > div + div,
+.spells div[data-epic-table-name=innate] + div[data-epic-table-name=innate] {
+  border-top: 1px solid rgba(181, 102, 50, 0.7);
 }
 .spells .skillTP-grid, .spells .TP-grid {
   color: #267200;

--- a/bin/main.html
+++ b/bin/main.html
@@ -233,35 +233,33 @@
     </div>
   </div>
   <!-- Defense -->
-  <div class="defenseBlock">
-    <div>
-      <label class="medium">+bonus</label>
-      <input class="center narrowish" name="attr_melee_boost" type="number" value="0" />
-      <input class="center narrowish" name="attr_ranged_boost" type="number" value="0" />
+  <div class="defense-block">
+    <div class="defenses epic-table-header-grid">
+      <div></div>
+      <div>Melee</div>
+      <div>Range</div>
     </div>
-    <div class="table-header">
-      <div class="medium larger"></div>
-      <div class="narrowish">Melee</div>
-      <div class="narrowish">Range</div>
+    <div class="defenses-table" data-epic-table-name="defenses">
+      <div class="table-label">+bonus</div>
+      <input class="center bold larger" name="attr_melee_boost" type="number" value="0" />
+      <input class="center bold larger" name="attr_ranged_boost" type="number" value="0" />
     </div>
-    <div class="children-separated no-shrink">
-      <div>
-        <div class="inline medium right larger bold">Dodge</div>
-        <input name="attr_dodge" type="hidden" />
-        <span class="center narrowish bold larger inline" name="attr_current_dodge_melee" value="0"></span>
-        <span class="center narrowish bold larger inline" name="attr_current_dodge_ranged" value="0"></span>
-      </div>
-      <div>
-        <div class="inline medium right larger bold">Parry</div>
-        <input class="center narrowish bold larger inline" name="attr_current_parry_melee" type="number" value="0" />
-        <span class="center narrowish bold larger inline">--</span>
-      </div>
-      <div>
-        <div class="inline medium right larger bold">Block</div>
-        <input name="attr_block" type="hidden" />
-        <span class="center narrowish bold larger inline" name="attr_current_block_melee" value="0"></span>
-        <span class="center narrowish bold larger inline" name="attr_current_block_ranged" value="0"></span>
-      </div>
+    <div class="defenses-table-row" data-epic-table-name="defenses">
+      <div class="table-label larger">Dodge</div>
+      <input name="attr_dodge" type="hidden" />
+      <span class="center bold larger" name="attr_current_dodge_melee" value="0"></span>
+      <span class="center bold larger" name="attr_current_dodge_ranged" value="0"></span>
+    </div>
+    <div class="defenses-table-row" data-epic-table-name="defenses">
+      <div class="table-label larger">Parry</div>
+      <input class="center bold larger" name="attr_current_parry_melee" type="number" value="0" />
+      <span class="center bold larger">--</span>
+    </div>
+    <div class="defenses-table-row" data-epic-table-name="defenses">
+      <div class="table-label larger">Block</div>
+      <input name="attr_block" type="hidden" />
+      <span class="center bold larger" name="attr_current_block_melee" value="0"></span>
+      <span class="center bold larger" name="attr_current_block_ranged" value="0"></span>
     </div>
   </div>
 
@@ -494,12 +492,20 @@ its value is used for css selection of its siblings.
       <div class="character-attributes-table" data-epic-table-name="character-attributes">
         <div class="character-attributes-name-grid">Race</div>
         <input class="character-attributes-value-grid" name="attr_race" type="text" />
+      </div>
+      <div class="character-attributes-table" data-epic-table-name="character-attributes">
         <div class="character-attributes-name-grid">Gender</div>
         <input class="character-attributes-value-grid" name="attr_gender" type="text" />
+      </div>
+      <div class="character-attributes-table" data-epic-table-name="character-attributes">
         <div class="character-attributes-name-grid">Height</div>
         <input class="character-attributes-value-grid" name="attr_height" type="text" />
+      </div>
+      <div class="character-attributes-table" data-epic-table-name="character-attributes">
         <div class="character-attributes-name-grid">Weight</div>
         <input class="character-attributes-value-grid" name="attr_weight" type="number" />
+      </div>
+      <div class="character-attributes-table" data-epic-table-name="character-attributes">
         <div class="character-attributes-name-grid">Age</div>
         <input class="character-attributes-value-grid" name="attr_age" type="number" />
       </div>

--- a/bin/main.html
+++ b/bin/main.html
@@ -233,7 +233,7 @@
     </div>
   </div>
   <!-- Defense -->
-  <div>
+  <div class="defenseBlock">
     <div>
       <label class="medium">+bonus</label>
       <input class="center narrowish" name="attr_melee_boost" type="number" value="0" />

--- a/ui/basicTab/basicTab.pug
+++ b/ui/basicTab/basicTab.pug
@@ -11,12 +11,16 @@ include ../global/advantages.pug
       .character-attributes-table(data-epic-table-name="character-attributes")
         .character-attributes-name-grid Race
         input.character-attributes-value-grid(name='attr_race' type='text')
+      .character-attributes-table(data-epic-table-name="character-attributes")
         .character-attributes-name-grid Gender
         input.character-attributes-value-grid(name='attr_gender' type='text')
+      .character-attributes-table(data-epic-table-name="character-attributes")
         .character-attributes-name-grid Height
         input.character-attributes-value-grid(name='attr_height' type='text')
+      .character-attributes-table(data-epic-table-name="character-attributes")
         .character-attributes-name-grid Weight
         input.character-attributes-value-grid(name='attr_weight' type='number')
+      .character-attributes-table(data-epic-table-name="character-attributes")
         .character-attributes-name-grid Age
         input.character-attributes-value-grid(name='attr_age' type='number')
     // Advantages and Disadvantages 

--- a/ui/basicTab/basicTab.scss
+++ b/ui/basicTab/basicTab.scss
@@ -9,6 +9,7 @@
   .character-attributes {
     $character-attributes-grid-template: getResponsiveGridWidths(64px, 96px);
     @include epic-table-grid('character-attributes', $character-attributes-grid-template);
+    @include epic-table-grid-row-border('character-attributes');
 
     .character-attributes-table {
       .character-attributes-name-grid {
@@ -25,7 +26,9 @@
   .advantages {
     $advantage-grid-template: getResponsiveGridWidths(160px, 48px, 32px);
     @include epic-table-grid('advantage', $advantage-grid-template);
+    @include epic-table-grid-row-border('advantage');
     @include epic-table-grid('extraadvantage', $advantage-grid-template);
+    @include epic-table-grid-row-border('extraadvantage');
 
     .advantage-grid, .extraadvantagename-grid {
       text-align: right !important;
@@ -44,6 +47,7 @@
   .feats {
     $feat-grid-template: getResponsiveGridWidths(32px, 160px, 48px);
     @include epic-table-grid('feat', $feat-grid-template);
+    @include epic-table-grid-row-border('feat');
 
     input.featname-grid {
       text-align: right !important;

--- a/ui/colors.scss
+++ b/ui/colors.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 $cp-color: blue;
 $tp-color: #267200;
 $paper-color: #c4bdaf;
@@ -11,4 +13,4 @@ $primary-highlight-color: #fff;
 $primary-background-color: lighten($primary-highlight-background-color, 50%);
 $selected-tab-color: $primary-highlight-background-color;
 $unselected-tab-color: $primary-background-color;
-$border-underline-color: $primary-highlight-background-color;
+$table-row-underline-color: color.scale($primary-highlight-background-color, $alpha: -30%);

--- a/ui/components/gridTable/gridTable.scss
+++ b/ui/components/gridTable/gridTable.scss
@@ -9,7 +9,8 @@ $grid-column-gap: 2px;
   column-gap: $grid-column-gap;
   background: $primary-highlight-background-color;
   color: $primary-highlight-color;
-  padding: $grid-padding;
+  padding: 0 $grid-padding;
+  margin-bottom: $grid-padding;
   word-break: break-word;
   > div {
     text-align: center;
@@ -57,9 +58,25 @@ $grid-column-gap: 2px;
     @include epic-table-header($grid-template);
   }
 
+  // TODO Deprecate the `repeating_` selector in favor of the second explicit row selector
   div[data-groupname="repeating_#{$epic-table-type}"] > div,
   div[data-epic-table-name="#{$epic-table-type}"] {
     @include epic-table-rows($grid-template);
+  }
+}
+
+@mixin epic-table-grid-row-border($epic-table-type) {
+  // TODO Deprecate the `repeating_` selector in favor of the second explicit row selector
+  div[data-groupname="repeating_#{$epic-table-type}"] > div,
+  div[data-epic-table-name="#{$epic-table-type}"] {
+    input, select, textarea {
+      border: unset;
+    }
+  }
+  // TODO Deprecate the `repeating_` selector in favor of the second explicit row selector
+  div[data-groupname="repeating_#{$epic-table-type}"] > div + div,
+  div[data-epic-table-name="#{$epic-table-type}"] + div[data-epic-table-name="#{$epic-table-type}"] {
+    border-top: 1px solid $table-row-underline-color;
   }
 }
 

--- a/ui/epicSkills/epicSkills.scss
+++ b/ui/epicSkills/epicSkills.scss
@@ -15,6 +15,7 @@
     40px // Base
   );
   @include epic-table-grid('skill', $skill-grid-template);
+  @include epic-table-grid-row-border('skill');
 
   .isdiscipline-grid[value="1"] {
     ~.skillability-grid, ~.skillattribute-grid, ~.skillbase-grid {

--- a/ui/equipment/equipment.scss
+++ b/ui/equipment/equipment.scss
@@ -9,13 +9,17 @@
 
   $armor-grid-template: getResponsiveGridWidths(5fr, 1fr, 1fr, 1fr, 5fr);
   @include epic-table-grid('armor', $armor-grid-template);
+  @include epic-table-grid-row-border('armor');
 
   $shield-grid-template: getResponsiveGridWidths(5fr, 1fr, 1fr, 1fr, 1fr, 5fr);
   @include epic-table-grid('shield', $shield-grid-template);
+  @include epic-table-grid-row-border('shield');
 
   $weapon-grid-template: getResponsiveGridWidths(5fr, 1fr, 1fr, 1fr, 1fr, 1fr, 5fr);
   @include epic-table-grid('weapon', $weapon-grid-template);
+  @include epic-table-grid-row-border('weapon');
 
   $item-grid-template: getResponsiveGridWidths(5fr, 1fr, 1fr, 1fr, 5fr);
   @include epic-table-grid('item', $item-grid-template);
+  @include epic-table-grid-row-border('item');
 }

--- a/ui/global/global.scss
+++ b/ui/global/global.scss
@@ -106,7 +106,7 @@
 }
 
 .children-separated> :not(:first-child) {
-  border: solid $border-underline-color;
+  border: solid $table-row-underline-color;
   border-width: 1px 0px 0px 0px;
 }
 

--- a/ui/overviewTab/overviewTab.scss
+++ b/ui/overviewTab/overviewTab.scss
@@ -1,7 +1,7 @@
 @import '../components/gridTable/gridTable.scss';
 
 @mixin underline-row() {
-  border: solid $border-underline-color;
+  border: solid $table-row-underline-color;
   border-width: 0px 0px 1px 0px;
   padding-top: 2px;
   padding-bottom: 2px;

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -68,6 +68,8 @@ $notes-popover-width: 16px;
   );
 
   @include epic-table-grid('arcane', $arcane-grid-template);
+  @include epic-table-grid-row-border('arcane');
+
   .isdiscipline-grid[value="1"] {
     ~:not(.skillname-grid, .skillTP-grid, .skillexpertise-grid) {
       opacity: 0;
@@ -90,6 +92,7 @@ $notes-popover-width: 16px;
 
   $divine-grid-template: getResponsiveGridWidths(6fr, $notes-popover-width, 1fr, 1fr, 2fr, 1fr, 1fr, 2fr);
   @include epic-table-grid('divine', $divine-grid-template);
+  @include epic-table-grid-row-border('divine');
 
   $innate-grid-template: getResponsiveGridWidths(
     40px, // Sphere?
@@ -104,6 +107,7 @@ $notes-popover-width: 16px;
     32px, // CP
   );
   @include epic-table-grid('innate', $innate-grid-template);
+  @include epic-table-grid-row-border('innate');
 
   .innatesphere-hidden[value|="S"]{
     ~.skillname-grid {

--- a/ui/topSection/components/defenseBlock.pug
+++ b/ui/topSection/components/defenseBlock.pug
@@ -1,0 +1,25 @@
+// Defense 
+div.defenseBlock
+  div
+    label.medium +bonus
+    input.center.narrowish(name='attr_melee_boost' type='number' value='0')
+    input.center.narrowish(name='attr_ranged_boost' type='number' value='0')
+  .table-header
+    .medium.larger
+    .narrowish Melee
+    .narrowish Range
+  .children-separated.no-shrink
+    div
+      .inline.medium.right.larger.bold Dodge
+      input(name='attr_dodge' type='hidden')
+      span.center.narrowish.bold.larger.inline(name='attr_current_dodge_melee' value='0')
+      span.center.narrowish.bold.larger.inline(name='attr_current_dodge_ranged' value='0')
+    div
+      .inline.medium.right.larger.bold Parry
+      input.center.narrowish.bold.larger.inline(name='attr_current_parry_melee' type='number' value='0')
+      span.center.narrowish.bold.larger.inline --
+    div
+      .inline.medium.right.larger.bold Block
+      input(name='attr_block' type='hidden')
+      span.center.narrowish.bold.larger.inline(name='attr_current_block_melee' value='0')
+      span.center.narrowish.bold.larger.inline(name='attr_current_block_ranged' value='0')

--- a/ui/topSection/components/defenseBlock.pug
+++ b/ui/topSection/components/defenseBlock.pug
@@ -1,25 +1,24 @@
 // Defense 
-div.defenseBlock
-  div
-    label.medium +bonus
-    input.center.narrowish(name='attr_melee_boost' type='number' value='0')
-    input.center.narrowish(name='attr_ranged_boost' type='number' value='0')
-  .table-header
-    .medium.larger
-    .narrowish Melee
-    .narrowish Range
-  .children-separated.no-shrink
+.defense-block
+  .defenses.epic-table-header-grid
     div
-      .inline.medium.right.larger.bold Dodge
-      input(name='attr_dodge' type='hidden')
-      span.center.narrowish.bold.larger.inline(name='attr_current_dodge_melee' value='0')
-      span.center.narrowish.bold.larger.inline(name='attr_current_dodge_ranged' value='0')
-    div
-      .inline.medium.right.larger.bold Parry
-      input.center.narrowish.bold.larger.inline(name='attr_current_parry_melee' type='number' value='0')
-      span.center.narrowish.bold.larger.inline --
-    div
-      .inline.medium.right.larger.bold Block
-      input(name='attr_block' type='hidden')
-      span.center.narrowish.bold.larger.inline(name='attr_current_block_melee' value='0')
-      span.center.narrowish.bold.larger.inline(name='attr_current_block_ranged' value='0')
+    div Melee
+    div Range
+  .defenses-table(data-epic-table-name="defenses")
+    .table-label +bonus
+    input.center.bold.larger(name='attr_melee_boost' type='number' value='0')
+    input.center.bold.larger(name='attr_ranged_boost' type='number' value='0')
+  .defenses-table(data-epic-table-name="defenses")
+    .table-label.larger Dodge
+    input(name='attr_dodge' type='hidden')
+    span.center.bold.larger(name='attr_current_dodge_melee' value='0')
+    span.center.bold.larger(name='attr_current_dodge_ranged' value='0')
+  .defenses-table(data-epic-table-name="defenses")
+    .table-label.larger Parry
+    input.center.bold.larger(name='attr_current_parry_melee' type='number' value='0')
+    span.center.bold.larger --
+  .defenses-table(data-epic-table-name="defenses")
+    .table-label.larger Block
+    input(name='attr_block' type='hidden')
+    span.center.bold.larger(name='attr_current_block_melee' value='0')
+    span.center.bold.larger(name='attr_current_block_ranged' value='0')

--- a/ui/topSection/components/defenseBlock.pug
+++ b/ui/topSection/components/defenseBlock.pug
@@ -8,16 +8,16 @@
     .table-label +bonus
     input.center.bold.larger(name='attr_melee_boost' type='number' value='0')
     input.center.bold.larger(name='attr_ranged_boost' type='number' value='0')
-  .defenses-table(data-epic-table-name="defenses")
+  .defenses-table-row(data-epic-table-name="defenses")
     .table-label.larger Dodge
     input(name='attr_dodge' type='hidden')
     span.center.bold.larger(name='attr_current_dodge_melee' value='0')
     span.center.bold.larger(name='attr_current_dodge_ranged' value='0')
-  .defenses-table(data-epic-table-name="defenses")
+  .defenses-table-row(data-epic-table-name="defenses")
     .table-label.larger Parry
     input.center.bold.larger(name='attr_current_parry_melee' type='number' value='0')
     span.center.bold.larger --
-  .defenses-table(data-epic-table-name="defenses")
+  .defenses-table-row(data-epic-table-name="defenses")
     .table-label.larger Block
     input(name='attr_block' type='hidden')
     span.center.bold.larger(name='attr_current_block_melee' value='0')

--- a/ui/topSection/components/defenseBlock.scss
+++ b/ui/topSection/components/defenseBlock.scss
@@ -1,3 +1,17 @@
-.defenseBlock {
-  display: block;
+@import '../../components/gridTable/gridTable.scss';
+
+.defense-block {
+  $defenses-grid-template: getResponsiveGridWidths(50px, 50px, 50px);
+  @include epic-table-grid('defenses', $defenses-grid-template);
+
+  .table-label {
+    text-align: right;
+    margin: auto;
+    margin-right: 2px;
+    font-weight: bold;
+  }
+
+  input[type=number] {
+    text-align: right;
+  }
 }

--- a/ui/topSection/components/defenseBlock.scss
+++ b/ui/topSection/components/defenseBlock.scss
@@ -3,6 +3,7 @@
 .defense-block {
   $defenses-grid-template: getResponsiveGridWidths(50px, 50px, 50px);
   @include epic-table-grid('defenses', $defenses-grid-template);
+  @include epic-table-grid-row-border('defenses');
 
   .table-label {
     text-align: right;

--- a/ui/topSection/components/defenseBlock.scss
+++ b/ui/topSection/components/defenseBlock.scss
@@ -1,0 +1,3 @@
+.defenseBlock {
+  display: block;
+}

--- a/ui/topSection/topSection.pug
+++ b/ui/topSection/topSection.pug
@@ -158,31 +158,7 @@
     div
       .attribute-name.wide.larger Speed
       span.narrowish.center.bold.larger.value(name='attr_speed')
-  // Defense 
-  div
-    div
-      label.medium +bonus
-      input.center.narrowish(name='attr_melee_boost' type='number' value='0')
-      input.center.narrowish(name='attr_ranged_boost' type='number' value='0')
-    .table-header
-      .medium.larger
-      .narrowish Melee
-      .narrowish Range
-    .children-separated.no-shrink
-      div
-        .inline.medium.right.larger.bold Dodge
-        input(name='attr_dodge' type='hidden')
-        span.center.narrowish.bold.larger.inline(name='attr_current_dodge_melee' value='0')
-        span.center.narrowish.bold.larger.inline(name='attr_current_dodge_ranged' value='0')
-      div
-        .inline.medium.right.larger.bold Parry
-        input.center.narrowish.bold.larger.inline(name='attr_current_parry_melee' type='number' value='0')
-        span.center.narrowish.bold.larger.inline --
-      div
-        .inline.medium.right.larger.bold Block
-        input(name='attr_block' type='hidden')
-        span.center.narrowish.bold.larger.inline(name='attr_current_block_melee' value='0')
-        span.center.narrowish.bold.larger.inline(name='attr_current_block_ranged' value='0')
+  include ./components/defenseBlock.pug
   = '\n'
   // HP, EP, SP 
   .children-separated.no-shrink

--- a/ui/topSection/topSection.scss
+++ b/ui/topSection/topSection.scss
@@ -10,6 +10,9 @@
     display: flex;
     align-items: center;
   }
+  .tab-holder {
+    margin-top: 4px;
+  }
+  @include popover-control('weightPenalties');
+  @import './components/defenseBlock.scss';
 }
-
-@include popover-control('weightPenalties');

--- a/ui/weightPenalties/weightPenalties.scss
+++ b/ui/weightPenalties/weightPenalties.scss
@@ -12,7 +12,7 @@
 }
 
 .weight-penalty-table>div:not(:last-child):not(.table-header) {
-  border-bottom: solid $border-underline-color 1px;
+  border-bottom: solid $table-row-underline-color 1px;
 }
 
 .weight-penalty-table>div> :nth-child(2) {


### PR DESCRIPTION
Fix #64 
Extract defense block into separate pug file, to make it easier to refactor
Convert defenses to grid
Add ability to put border between each row in grid

Restyle tables with a row divider.

## Screenies

| Old | New |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/5629800/212575736-85905b15-bb52-4877-8ff5-b00094fdea13.png) | ![image](https://user-images.githubusercontent.com/5629800/212575771-e2fa5491-8d84-487e-9b77-35077613f0f0.png) |
| ![image](https://user-images.githubusercontent.com/5629800/212575741-61cd1509-c27a-4bb2-ae0d-e6a819ef033d.png) | ![image](https://user-images.githubusercontent.com/5629800/212575775-c87fe589-5ab3-427d-b95c-50b262db8869.png) |
| ![image](https://user-images.githubusercontent.com/5629800/212575744-0781db93-89aa-4da1-83a2-242656b4ffca.png) | ![image](https://user-images.githubusercontent.com/5629800/212575778-02d6d524-fd04-4cae-8a33-93f5c6a15ae6.png) |
| ![image](https://user-images.githubusercontent.com/5629800/212575764-71146fca-8b48-4b01-904f-9fb0f1aa9add.png) | ![image](https://user-images.githubusercontent.com/5629800/212575797-bb918ae6-b90a-45c7-a86f-987d3e60fb73.png) |
