### PR TITLE
Refactor defense table and values

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -593,7 +593,7 @@ radio > span.checked {
 }
 .top-section .defense-block .epic-table-header-grid.defenses {
   display: grid;
-  grid-template-columns: minmax(0, 50px) minmax(0, 50px) minmax(0, 50px);
+  grid-template-columns: minmax(0, 50px) minmax(0, 80px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -609,7 +609,7 @@ radio > span.checked {
 .top-section .defense-block div[data-groupname=repeating_defenses] > div,
 .top-section .defense-block div[data-epic-table-name=defenses] {
   display: grid;
-  grid-template-columns: minmax(0, 50px) minmax(0, 50px) minmax(0, 50px);
+  grid-template-columns: minmax(0, 50px) minmax(0, 80px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -648,7 +648,7 @@ radio > span.checked {
 .top-section .defense-block div[data-epic-table-name=defenses] .epic-table-row.conditional-one {
   display: grid;
   grid-column-start: 1;
-  grid-column-end: 4;
+  grid-column-end: 3;
 }
 .top-section .defense-block div[data-groupname=repeating_defenses] > div input, .top-section .defense-block div[data-groupname=repeating_defenses] > div select, .top-section .defense-block div[data-groupname=repeating_defenses] > div textarea,
 .top-section .defense-block div[data-epic-table-name=defenses] input,
@@ -667,7 +667,7 @@ radio > span.checked {
   font-weight: bold;
 }
 .top-section .defense-block input[type=number] {
-  text-align: right;
+  text-align: center;
 }
 
 /* ------ generic conditional appearance ------ */

--- a/bin/main.css
+++ b/bin/main.css
@@ -91,6 +91,10 @@ div.popoverContainer > .fixedPlacementPopover {
   top: 105%;
   left: 0;
 }
+.epic-tooltip .epic-tooltip-text.right {
+  top: -8px;
+  left: 110%;
+}
 .epic-tooltip:hover .epic-tooltip-text {
   visibility: visible;
 }
@@ -591,9 +595,71 @@ radio > span.checked {
 .top-section input.popoverController[value="1"] ~ div.popoverContainer.weightPenalties .popover {
   display: block;
 }
+.top-section .defense-block .armor-header {
+  text-decoration: line-through;
+}
+.top-section .defense-block .epic-table-header-grid.defenses-with-spanning-input {
+  display: grid;
+  grid-template-columns: minmax(0, 50px) minmax(0, 100px);
+  column-gap: 2px;
+  background: #b56632;
+  color: #fff;
+  padding: 0 2px;
+  margin-bottom: 2px;
+  word-break: break-word;
+}
+.top-section .defense-block .epic-table-header-grid.defenses-with-spanning-input > div {
+  text-align: center;
+  margin: auto;
+  font-weight: bold;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div,
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] {
+  display: grid;
+  grid-template-columns: minmax(0, 50px) minmax(0, 100px);
+  row-gap: 0;
+  column-gap: 2px;
+  background: transparent;
+  word-break: break-word;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div input, .top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div input[type=number], .top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div textarea, .top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div select,
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] input,
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] input[type=number],
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] textarea,
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] select {
+  width: 100% !important;
+  margin-left: unset;
+  height: auto;
+  background-color: #faf2ec;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div input[type=text],
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] input[type=text] {
+  text-align: left;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div input, .top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div select,
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] input,
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] select {
+  white-space: nowrap;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div span,
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] span {
+  text-align: center;
+  margin: auto 0;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div button, .top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div button[type=roll],
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] button,
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] button[type=roll] {
+  margin: 0;
+}
+.top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div .epic-table-row.conditional-one,
+.top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] .epic-table-row.conditional-one {
+  display: grid;
+  grid-column-start: 1;
+  grid-column-end: 3;
+}
 .top-section .defense-block .epic-table-header-grid.defenses {
   display: grid;
-  grid-template-columns: minmax(0, 50px) minmax(0, 80px);
+  grid-template-columns: minmax(0, 50px) minmax(0, 50px) minmax(0, 50px);
   column-gap: 2px;
   background: #b56632;
   color: #fff;
@@ -609,7 +675,7 @@ radio > span.checked {
 .top-section .defense-block div[data-groupname=repeating_defenses] > div,
 .top-section .defense-block div[data-epic-table-name=defenses] {
   display: grid;
-  grid-template-columns: minmax(0, 50px) minmax(0, 80px);
+  grid-template-columns: minmax(0, 50px) minmax(0, 50px) minmax(0, 50px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -648,7 +714,7 @@ radio > span.checked {
 .top-section .defense-block div[data-epic-table-name=defenses] .epic-table-row.conditional-one {
   display: grid;
   grid-column-start: 1;
-  grid-column-end: 3;
+  grid-column-end: 4;
 }
 .top-section .defense-block div[data-groupname=repeating_defenses] > div input, .top-section .defense-block div[data-groupname=repeating_defenses] > div select, .top-section .defense-block div[data-groupname=repeating_defenses] > div textarea,
 .top-section .defense-block div[data-epic-table-name=defenses] input,
@@ -659,6 +725,9 @@ radio > span.checked {
 .top-section .defense-block div[data-groupname=repeating_defenses] > div + div,
 .top-section .defense-block div[data-epic-table-name=defenses] + div[data-epic-table-name=defenses] {
   border-top: 1px solid rgba(181, 102, 50, 0.7);
+}
+.top-section .defense-block div.bonus-row, .top-section .defense-block div.parry-row {
+  grid-template-columns: minmax(0, 50px) minmax(0, 100px);
 }
 .top-section .defense-block .table-label {
   text-align: right;

--- a/bin/main.html
+++ b/bin/main.html
@@ -236,27 +236,27 @@
   <div class="defense-block">
     <div class="defenses epic-table-header-grid">
       <div>Def.</div>
-      <div>Armor</div>
+      <div>Ability</div>
+      <div class="armor-header epic-tooltip">Armor<span class="epic-tooltip-text right">Ability without Armor</span>
+      </div>
     </div>
-    <div class="defenses-table" data-epic-table-name="defenses">
+    <div class="defenses-table-row bonus-row" data-epic-table-name="defenses">
       <div class="table-label">+bonus</div>
       <input class="center bold larger" name="attr_defense_boost" type="number" value="0" />
     </div>
     <div class="defenses-table-row" data-epic-table-name="defenses">
       <div class="table-label larger">Dodge</div>
       <input name="attr_dodge" type="hidden" />
-      <span class="center bold larger">
-        <span name="attr_current_dodge_with_armor" value="0"></span>&nbsp;(<span name="attr_current_dodge_base" value="0"></span>)
-      </span>
+      <span class="center bold larger" name="attr_current_dodge_with_armor" value="0"></span>
+      <span class="center bold larger" name="attr_current_dodge_base" value="0"></span>
     </div>
     <div class="defenses-table-row" data-epic-table-name="defenses">
       <div class="table-label larger">Block</div>
       <input name="attr_block" type="hidden" />
-      <span class="center bold larger">
-        <span name="attr_current_block_with_armor" value="0"></span>&nbsp;(<span name="attr_current_block_base" value="0"></span>)
-      </span>
+      <span class="center bold larger" name="attr_current_block_with_armor" value="0"></span>
+      <span class="center bold larger" name="attr_current_block_base" value="0"></span>
     </div>
-    <div class="defenses-table-row" data-epic-table-name="defenses">
+    <div class="defenses-table-row parry-row" data-epic-table-name="defenses">
       <div class="table-label larger">Parry</div>
       <input class="center bold larger" name="attr_current_parry" type="number" value="0" />
     </div>

--- a/bin/main.html
+++ b/bin/main.html
@@ -248,13 +248,13 @@
       <div class="table-label larger">Dodge</div>
       <input name="attr_dodge" type="hidden" />
       <span class="center bold larger" name="attr_current_dodge_with_armor" value="0"></span>
-      <span class="center bold larger" name="attr_current_dodge_base" value="0"></span>
+      <span class="center bold larger" name="attr_current_dodge_without_armor" value="0"></span>
     </div>
     <div class="defenses-table-row" data-epic-table-name="defenses">
       <div class="table-label larger">Block</div>
       <input name="attr_block" type="hidden" />
       <span class="center bold larger" name="attr_current_block_with_armor" value="0"></span>
-      <span class="center bold larger" name="attr_current_block_base" value="0"></span>
+      <span class="center bold larger" name="attr_current_block_without_armor" value="0"></span>
     </div>
     <div class="defenses-table-row parry-row" data-epic-table-name="defenses">
       <div class="table-label larger">Parry</div>
@@ -2133,7 +2133,7 @@ const updateArmorValue = function () {
           - Math.abs(Number(values[reactionPenaltyName]))
         );
         let total = base + Number(values['defense_boost']);
-        update[`current_${defense}_base`] = String(total);
+        update[`current_${defense}_without_armor`] = String(total);
         update[`current_${defense}_with_armor`] = String(total + cur_armor);
       }
       setAttrs(update);

--- a/bin/main.html
+++ b/bin/main.html
@@ -235,31 +235,30 @@
   <!-- Defense -->
   <div class="defense-block">
     <div class="defenses epic-table-header-grid">
-      <div></div>
-      <div>Melee</div>
-      <div>Range</div>
+      <div>Def.</div>
+      <div>Armor</div>
     </div>
     <div class="defenses-table" data-epic-table-name="defenses">
       <div class="table-label">+bonus</div>
-      <input class="center bold larger" name="attr_melee_boost" type="number" value="0" />
-      <input class="center bold larger" name="attr_ranged_boost" type="number" value="0" />
+      <input class="center bold larger" name="attr_defense_boost" type="number" value="0" />
     </div>
     <div class="defenses-table-row" data-epic-table-name="defenses">
       <div class="table-label larger">Dodge</div>
       <input name="attr_dodge" type="hidden" />
-      <span class="center bold larger" name="attr_current_dodge_melee" value="0"></span>
-      <span class="center bold larger" name="attr_current_dodge_ranged" value="0"></span>
-    </div>
-    <div class="defenses-table-row" data-epic-table-name="defenses">
-      <div class="table-label larger">Parry</div>
-      <input class="center bold larger" name="attr_current_parry_melee" type="number" value="0" />
-      <span class="center bold larger">--</span>
+      <span class="center bold larger">
+        <span name="attr_current_dodge_with_armor" value="0"></span>&nbsp;(<span name="attr_current_dodge_base" value="0"></span>)
+      </span>
     </div>
     <div class="defenses-table-row" data-epic-table-name="defenses">
       <div class="table-label larger">Block</div>
       <input name="attr_block" type="hidden" />
-      <span class="center bold larger" name="attr_current_block_melee" value="0"></span>
-      <span class="center bold larger" name="attr_current_block_ranged" value="0"></span>
+      <span class="center bold larger">
+        <span name="attr_current_block_with_armor" value="0"></span>&nbsp;(<span name="attr_current_block_base" value="0"></span>)
+      </span>
+    </div>
+    <div class="defenses-table-row" data-epic-table-name="defenses">
+      <div class="table-label larger">Parry</div>
+      <input class="center bold larger" name="attr_current_parry" type="number" value="0" />
     </div>
   </div>
 
@@ -2116,35 +2115,32 @@ on('remove:repeating_skill',
 
 // -------------- Equipment -------------
 const updateArmorValue = function () {
-  const armor = 'armor_defense';
-  const shield = 'shield_defense';
-  const melee = 'melee_boost';
-  const ranged = 'ranged_boost';
-  const defend = 'defend';
-  const reaction = 'reaction_penalty';
-  getAttrs([armor, shield, melee, ranged, defend, reaction],
+  const armorName = 'armor_defense';
+  const shieldName = 'shield_defense';
+  const defenseBoostName = 'defense_boost';
+  const defendName = 'defend';
+  const reactionPenaltyName = 'reaction_penalty';
+  getAttrs([armorName, shieldName, defenseBoostName, defendName, reactionPenaltyName],
     function(values) {
-      const cur_armor = Number(values[armor]);
-      const cur_shield = Number(values[shield]);
-      // const cur_reaction = Number(values[reaction]);
-      const cur_defend = Number(values['defend']) + cur_armor;
-      let update = {};
+      const cur_armor = Number(values[armorName]);
+      const cur_shield = Number(values[shieldName]);
+      const cur_defend = Number(values[defendName]);
+      const update = {};
       for (let defense of ['dodge', 'block']) {
         let base = (
           cur_defend
           + (defense === 'block' ? cur_shield : 0)
-          - Math.abs(Number(values[reaction]))
+          - Math.abs(Number(values[reactionPenaltyName]))
         );
-        for (let attack of ['melee', 'ranged']) {
-          let total = base + Number(values[attack + '_boost']);
-          update['current_' + defense + '_' + attack] = String(total);
-        }
+        let total = base + Number(values['defense_boost']);
+        update[`current_${defense}_base`] = String(total);
+        update[`current_${defense}_with_armor`] = String(total + cur_armor);
       }
       setAttrs(update);
     });
 };
 on('change:armor_defense change:shield_defense change:defend' +
-    ' change:melee_boost change:ranged_boost change:reaction_penalty',
+    ' change:defense_boost change:reaction_penalty sheet:opened',
 updateArmorValue);
 
 const updateSpeed = function () {

--- a/bin/main.html
+++ b/bin/main.html
@@ -2127,14 +2127,21 @@ const updateArmorValue = function () {
       const cur_defend = Number(values[defendName]);
       const update = {};
       for (let defense of ['dodge', 'block']) {
-        let base = (
+        const defenseIsArmor = defense === 'dodge';
+        const defenseIsBlock = defense === 'block';
+        const base = (
           cur_defend
-          + (defense === 'block' ? cur_shield : 0)
+          + (defenseIsBlock ? cur_shield : 0)
           - Math.abs(Number(values[reactionPenaltyName]))
         );
-        let total = base + Number(values['defense_boost']);
-        update[`current_${defense}_without_armor`] = String(total);
-        update[`current_${defense}_with_armor`] = String(total + cur_armor);
+        const total = base + Number(values['defense_boost']);
+        /**
+         * Block is only valid if there is a shield value.
+         */
+        const blockIsValid = defenseIsBlock && cur_shield && !Number.isNaN(cur_shield);
+        const defenseIsValid = defenseIsArmor || blockIsValid;
+        update[`current_${defense}_without_armor`] = defenseIsValid ? String(total) : '--';
+        update[`current_${defense}_with_armor`] = defenseIsValid ? String(total + cur_armor) : '--';
       }
       setAttrs(update);
     });

--- a/ui/components/tooltip/tooltip.scss
+++ b/ui/components/tooltip/tooltip.scss
@@ -16,6 +16,10 @@
     z-index: 1;
     top: 105%;
     left: 0;
+    &.right {
+      top: -8px;
+      left: 110%;
+    }
   }
 
   &:hover .epic-tooltip-text {

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1048,14 +1048,21 @@ const updateArmorValue = function () {
       const cur_defend = Number(values[defendName]);
       const update = {};
       for (let defense of ['dodge', 'block']) {
-        let base = (
+        const defenseIsArmor = defense === 'dodge';
+        const defenseIsBlock = defense === 'block';
+        const base = (
           cur_defend
-          + (defense === 'block' ? cur_shield : 0)
+          + (defenseIsBlock ? cur_shield : 0)
           - Math.abs(Number(values[reactionPenaltyName]))
         );
-        let total = base + Number(values['defense_boost']);
-        update[`current_${defense}_without_armor`] = String(total);
-        update[`current_${defense}_with_armor`] = String(total + cur_armor);
+        const total = base + Number(values['defense_boost']);
+        /**
+         * Block is only valid if there is a shield value.
+         */
+        const blockIsValid = defenseIsBlock && cur_shield && !Number.isNaN(cur_shield);
+        const defenseIsValid = defenseIsArmor || blockIsValid;
+        update[`current_${defense}_without_armor`] = defenseIsValid ? String(total) : '--';
+        update[`current_${defense}_with_armor`] = defenseIsValid ? String(total + cur_armor) : '--';
       }
       setAttrs(update);
     });

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1054,7 +1054,7 @@ const updateArmorValue = function () {
           - Math.abs(Number(values[reactionPenaltyName]))
         );
         let total = base + Number(values['defense_boost']);
-        update[`current_${defense}_base`] = String(total);
+        update[`current_${defense}_without_armor`] = String(total);
         update[`current_${defense}_with_armor`] = String(total + cur_armor);
       }
       setAttrs(update);

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1036,35 +1036,32 @@ on('remove:repeating_skill',
 
 // -------------- Equipment -------------
 const updateArmorValue = function () {
-  const armor = 'armor_defense';
-  const shield = 'shield_defense';
-  const melee = 'melee_boost';
-  const ranged = 'ranged_boost';
-  const defend = 'defend';
-  const reaction = 'reaction_penalty';
-  getAttrs([armor, shield, melee, ranged, defend, reaction],
+  const armorName = 'armor_defense';
+  const shieldName = 'shield_defense';
+  const defenseBoostName = 'defense_boost';
+  const defendName = 'defend';
+  const reactionPenaltyName = 'reaction_penalty';
+  getAttrs([armorName, shieldName, defenseBoostName, defendName, reactionPenaltyName],
     function(values) {
-      const cur_armor = Number(values[armor]);
-      const cur_shield = Number(values[shield]);
-      // const cur_reaction = Number(values[reaction]);
-      const cur_defend = Number(values['defend']) + cur_armor;
-      let update = {};
+      const cur_armor = Number(values[armorName]);
+      const cur_shield = Number(values[shieldName]);
+      const cur_defend = Number(values[defendName]);
+      const update = {};
       for (let defense of ['dodge', 'block']) {
         let base = (
           cur_defend
           + (defense === 'block' ? cur_shield : 0)
-          - Math.abs(Number(values[reaction]))
+          - Math.abs(Number(values[reactionPenaltyName]))
         );
-        for (let attack of ['melee', 'ranged']) {
-          let total = base + Number(values[attack + '_boost']);
-          update['current_' + defense + '_' + attack] = String(total);
-        }
+        let total = base + Number(values['defense_boost']);
+        update[`current_${defense}_base`] = String(total);
+        update[`current_${defense}_with_armor`] = String(total + cur_armor);
       }
       setAttrs(update);
     });
 };
 on('change:armor_defense change:shield_defense change:defend' +
-    ' change:melee_boost change:ranged_boost change:reaction_penalty',
+    ' change:defense_boost change:reaction_penalty sheet:opened',
 updateArmorValue);
 
 const updateSpeed = function () {

--- a/ui/topSection/components/defenseBlock.pug
+++ b/ui/topSection/components/defenseBlock.pug
@@ -12,12 +12,12 @@
     .table-label.larger Dodge
     input(name='attr_dodge' type='hidden')
     span.center.bold.larger(name='attr_current_dodge_with_armor' value='0')
-    span.center.bold.larger(name='attr_current_dodge_base' value='0')
+    span.center.bold.larger(name='attr_current_dodge_without_armor' value='0')
   .defenses-table-row(data-epic-table-name="defenses")
     .table-label.larger Block
     input(name='attr_block' type='hidden')
     span.center.bold.larger(name='attr_current_block_with_armor' value='0')
-    span.center.bold.larger(name='attr_current_block_base' value='0')
+    span.center.bold.larger(name='attr_current_block_without_armor' value='0')
   .defenses-table-row.parry-row(data-epic-table-name="defenses")
     .table-label.larger Parry
     input.center.bold.larger(name='attr_current_parry' type='number' value='0')

--- a/ui/topSection/components/defenseBlock.pug
+++ b/ui/topSection/components/defenseBlock.pug
@@ -2,12 +2,12 @@
 .defense-block
   .defenses.epic-table-header-grid
     div Def.
-    div Armor
-    div Base
-  .defenses-table(data-epic-table-name="defenses")
+    div Ability
+    div.armor-header.epic-tooltip Armor
+      span.epic-tooltip-text.right Ability without Armor
+  .defenses-table-row.bonus-row(data-epic-table-name="defenses")
     .table-label +bonus
     input.center.bold.larger(name='attr_defense_boost' type='number' value='0')
-    span.center.bold.larger --
   .defenses-table-row(data-epic-table-name="defenses")
     .table-label.larger Dodge
     input(name='attr_dodge' type='hidden')
@@ -18,7 +18,6 @@
     input(name='attr_block' type='hidden')
     span.center.bold.larger(name='attr_current_block_with_armor' value='0')
     span.center.bold.larger(name='attr_current_block_base' value='0')
-  .defenses-table-row(data-epic-table-name="defenses")
+  .defenses-table-row.parry-row(data-epic-table-name="defenses")
     .table-label.larger Parry
     input.center.bold.larger(name='attr_current_parry' type='number' value='0')
-    span.center.bold.larger --

--- a/ui/topSection/components/defenseBlock.pug
+++ b/ui/topSection/components/defenseBlock.pug
@@ -1,24 +1,24 @@
 // Defense 
 .defense-block
   .defenses.epic-table-header-grid
-    div
-    div Melee
-    div Range
+    div Def.
+    div Armor
+    div Base
   .defenses-table(data-epic-table-name="defenses")
     .table-label +bonus
-    input.center.bold.larger(name='attr_melee_boost' type='number' value='0')
-    input.center.bold.larger(name='attr_ranged_boost' type='number' value='0')
+    input.center.bold.larger(name='attr_defense_boost' type='number' value='0')
+    span.center.bold.larger --
   .defenses-table-row(data-epic-table-name="defenses")
     .table-label.larger Dodge
     input(name='attr_dodge' type='hidden')
-    span.center.bold.larger(name='attr_current_dodge_melee' value='0')
-    span.center.bold.larger(name='attr_current_dodge_ranged' value='0')
-  .defenses-table-row(data-epic-table-name="defenses")
-    .table-label.larger Parry
-    input.center.bold.larger(name='attr_current_parry_melee' type='number' value='0')
-    span.center.bold.larger --
+    span.center.bold.larger(name='attr_current_dodge_with_armor' value='0')
+    span.center.bold.larger(name='attr_current_dodge_base' value='0')
   .defenses-table-row(data-epic-table-name="defenses")
     .table-label.larger Block
     input(name='attr_block' type='hidden')
-    span.center.bold.larger(name='attr_current_block_melee' value='0')
-    span.center.bold.larger(name='attr_current_block_ranged' value='0')
+    span.center.bold.larger(name='attr_current_block_with_armor' value='0')
+    span.center.bold.larger(name='attr_current_block_base' value='0')
+  .defenses-table-row(data-epic-table-name="defenses")
+    .table-label.larger Parry
+    input.center.bold.larger(name='attr_current_parry' type='number' value='0')
+    span.center.bold.larger --

--- a/ui/topSection/components/defenseBlock.scss
+++ b/ui/topSection/components/defenseBlock.scss
@@ -1,9 +1,17 @@
 @import '../../components/gridTable/gridTable.scss';
 
 .defense-block {
+  .armor-header {
+    text-decoration: line-through;
+  }
+  $defenses-grid-template-with-spanning-input: getResponsiveGridWidths(50px, 100px);
+  @include epic-table-grid('defenses-with-spanning-input', $defenses-grid-template-with-spanning-input);
   $defenses-grid-template: getResponsiveGridWidths(50px, 50px, 50px);
   @include epic-table-grid('defenses', $defenses-grid-template);
   @include epic-table-grid-row-border('defenses');
+  div.bonus-row, div.parry-row {
+    grid-template-columns: $defenses-grid-template-with-spanning-input;
+  }
 
   .table-label {
     text-align: right;
@@ -13,6 +21,6 @@
   }
 
   input[type=number] {
-    text-align: right;
+    text-align: center;
   }
 }


### PR DESCRIPTION
Change the defense table content to match the rules.
Fix #35 

Remove split between melee and ranged.
Rename attributes to match.
Clean up code.

Make some columns double width.
Add tooltip to `Armor` header.

![image](https://user-images.githubusercontent.com/5629800/212787853-659ce45c-9302-459c-9b9d-d71c9c5dc91c.png)
Also, tooltip when hovering:
![image](https://user-images.githubusercontent.com/5629800/212787910-60b2de1c-3114-497c-b4d2-422db614366c.png)

When no shield (see last commit):
![image](https://user-images.githubusercontent.com/5629800/212791711-ff3ba029-08af-4314-a21e-8d72fef0db78.png)
