### PR TITLE
Update parry field to use largest weapon defense

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -727,7 +727,7 @@ radio > span.checked {
 .top-section .defense-block div[data-epic-table-name=defenses] + div[data-epic-table-name=defenses] {
   border-top: 1px solid rgba(181, 102, 50, 0.7);
 }
-.top-section .defense-block div.bonus-row, .top-section .defense-block div.parry-row {
+.top-section .defense-block div.bonus-row {
   grid-template-columns: minmax(0, 50px) minmax(0, 100px);
 }
 .top-section .defense-block .table-label {

--- a/bin/main.html
+++ b/bin/main.html
@@ -258,7 +258,8 @@
     </div>
     <div class="defenses-table-row parry-row" data-epic-table-name="defenses">
       <div class="table-label larger">Parry</div>
-      <input class="center bold larger" name="attr_current_parry" type="number" value="0" />
+      <span class="center bold larger" name="attr_current_parry_with_armor" type="number" value="0"></span>
+      <span class="center bold larger" name="attr_current_parry_without_armor" type="number" value="0"></span>
     </div>
   </div>
 
@@ -2130,40 +2131,69 @@ on('remove:repeating_skill',
   });
 
 // -------------- Equipment -------------
+function getLargestWeaponDefense(callback) {
+  getSectionIDs('weapon', function (ids) {
+    const defenseFields = ids.map(
+      id => `repeating_weapon_${id}_weapondefense`);
+    const countFields = ids.map(
+      id => `repeating_weapon_${id}_weaponcount`);
+    getAttrs([...defenseFields, ...countFields], function (values) {
+      const largestWeaponDefense = defenseFields.reduce((memo, defenseFieldName, i) => {
+        const defense = Number(values[defenseFieldName]);
+        const count = Number(values[countFields[i]]);
+        if (defense > 0 && count > 0) {
+          return Math.max(memo, defense);
+        }
+        return memo;
+      }, 0);
+      callback(largestWeaponDefense);
+      console.log(`Largest Weapon Defense: ${largestWeaponDefense}`);
+    });
+  });
+
+}
+
 const updateArmorValue = function () {
   const armorName = 'armor_defense';
   const shieldName = 'shield_defense';
   const defenseBoostName = 'defense_boost';
   const defendName = 'defend';
   const reactionPenaltyName = 'reaction_penalty';
-  getAttrs([armorName, shieldName, defenseBoostName, defendName, reactionPenaltyName],
-    function(values) {
-      const cur_armor = Number(values[armorName]);
-      const cur_shield = Number(values[shieldName]);
-      const cur_defend = Number(values[defendName]);
-      const update = {};
-      for (let defense of ['dodge', 'block']) {
-        const defenseIsArmor = defense === 'dodge';
-        const defenseIsBlock = defense === 'block';
-        const base = (
-          cur_defend
-          + (defenseIsBlock ? cur_shield : 0)
-          - Math.abs(Number(values[reactionPenaltyName]))
-        );
-        const total = base + Number(values['defense_boost']);
-        /**
-         * Block is only valid if there is a shield value.
-         */
-        const blockIsValid = defenseIsBlock && cur_shield && !Number.isNaN(cur_shield);
-        const defenseIsValid = defenseIsArmor || blockIsValid;
-        update[`current_${defense}_without_armor`] = defenseIsValid ? String(total) : '--';
-        update[`current_${defense}_with_armor`] = defenseIsValid ? String(total + cur_armor) : '--';
-      }
-      setAttrs(update);
-    });
+  getLargestWeaponDefense((largestWeaponDefense) => {
+    getAttrs([armorName, shieldName, defenseBoostName, defendName, reactionPenaltyName],
+      function(values) {
+        const cur_armor = Number(values[armorName]);
+        const cur_shield = Number(values[shieldName]);
+        const cur_defend = Number(values[defendName]);
+        const update = {};
+        for (let defense of ['dodge', 'block', 'parry']) {
+          const defenseIsArmor = defense === 'dodge';
+          const defenseIsBlock = defense === 'block';
+          const defenseIsParry = defense === 'parry';
+          const base = (
+            cur_defend
+            + (defenseIsBlock ? cur_shield : 0)
+            + (defenseIsParry ? largestWeaponDefense : 0)
+            - Math.abs(Number(values[reactionPenaltyName]))
+          );
+          const total = base + Number(values['defense_boost']);
+          /**
+           * Block is only valid if there is a shield value.
+           */
+          const blockIsValid = defenseIsBlock && cur_shield && !Number.isNaN(cur_shield);
+          const parryIsValid = defenseIsParry && largestWeaponDefense && !Number.isNaN(largestWeaponDefense);
+          const defenseIsValid = defenseIsArmor || blockIsValid || parryIsValid;
+          update[`current_${defense}_without_armor`] = defenseIsValid ? String(total) : '--';
+          update[`current_${defense}_with_armor`] = defenseIsValid ? String(total + cur_armor) : '--';
+        }
+        setAttrs(update);
+      });
+  });
 };
 on('change:armor_defense change:shield_defense change:defend' +
-    ' change:defense_boost change:reaction_penalty sheet:opened',
+  ' change:repeating_weapon:weaponcount' + 
+  ' change:repeating_weapon:weapondefense remove:repeating_weapon' +
+  ' change:defense_boost change:reaction_penalty sheet:opened',
 updateArmorValue);
 
 const updateSpeed = function () {

--- a/bin/main.html
+++ b/bin/main.html
@@ -2147,7 +2147,6 @@ function getLargestWeaponDefense(callback) {
         return memo;
       }, 0);
       callback(largestWeaponDefense);
-      console.log(`Largest Weapon Defense: ${largestWeaponDefense}`);
     });
   });
 

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1051,7 +1051,6 @@ function getLargestWeaponDefense(callback) {
         return memo;
       }, 0);
       callback(largestWeaponDefense);
-      console.log(`Largest Weapon Defense: ${largestWeaponDefense}`);
     });
   });
 

--- a/ui/topSection/components/defenseBlock.pug
+++ b/ui/topSection/components/defenseBlock.pug
@@ -20,4 +20,5 @@
     span.center.bold.larger(name='attr_current_block_without_armor' value='0')
   .defenses-table-row.parry-row(data-epic-table-name="defenses")
     .table-label.larger Parry
-    input.center.bold.larger(name='attr_current_parry' type='number' value='0')
+    span.center.bold.larger(name='attr_current_parry_with_armor' type='number' value='0')
+    span.center.bold.larger(name='attr_current_parry_without_armor' type='number' value='0')

--- a/ui/topSection/components/defenseBlock.scss
+++ b/ui/topSection/components/defenseBlock.scss
@@ -9,7 +9,7 @@
   $defenses-grid-template: getResponsiveGridWidths(50px, 50px, 50px);
   @include epic-table-grid('defenses', $defenses-grid-template);
   @include epic-table-grid-row-border('defenses');
-  div.bonus-row, div.parry-row {
+  div.bonus-row {
     grid-template-columns: $defenses-grid-template-with-spanning-input;
   }
 


### PR DESCRIPTION
Fix Rework Parry fields #69

* Use the highest bonus as the bonus for parry.
* Show `--` when no weapon has parry bonus
* Verified that calculation is right. (Including bonus, armor, weight penalty)

![image](https://user-images.githubusercontent.com/5629800/213899453-e032ac20-2669-4f68-9468-d7c34236a5f4.png) ![image](https://user-images.githubusercontent.com/5629800/213899458-a3ec23b3-997e-42b7-9067-0e228f456233.png)