### PR TITLE
Fix a minor issue with max EP per turn

### DIFF
--- a/bin/main.html
+++ b/bin/main.html
@@ -1337,7 +1337,7 @@ const makeUpdate = function(current, deltas) {
   let EP_delta = modifiersToTotal(deltas['EPS']);
   const current_EP_t = Number(current['EP_t']);
   const EP_t_max = Number(current['EP_t_max']);
-  const new_EP_t = Math.max(0, Math.min(EP_t_max, current_EP_t + EP_delta));
+  const new_EP_t = Math.max(0, Math.min(EP_t_max * 2, current_EP_t + EP_delta));
   // log("EP_delta " + EP_delta + "  current_EP_t " + current_EP_t);
   // log("EP_t_max " + EP_t_max + "  new_EP_t" + new_EP_t);
   return {'EP_t': new_EP_t,

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -241,7 +241,7 @@ const makeUpdate = function(current, deltas) {
   let EP_delta = modifiersToTotal(deltas['EPS']);
   const current_EP_t = Number(current['EP_t']);
   const EP_t_max = Number(current['EP_t_max']);
-  const new_EP_t = Math.max(0, Math.min(EP_t_max, current_EP_t + EP_delta));
+  const new_EP_t = Math.max(0, Math.min(EP_t_max * 2, current_EP_t + EP_delta));
   // log("EP_delta " + EP_delta + "  current_EP_t " + current_EP_t);
   // log("EP_t_max " + EP_t_max + "  new_EP_t" + new_EP_t);
   return {'EP_t': new_EP_t,


### PR DESCRIPTION
After doing an attack or action roll, the remaining EP calculation should be correct, even if above 1x base.

Steps to reproduce:
1. Set EP to be base+2 or more. For example, if base is 10, then set to 12 or more.
2. Set boost to 1
3. Click dice roll attack

Observe that the EP becomes base
Expect that it calculates to original EP minus 1.

This appears to be simply a bug in the math that has been around for a while.