### PR TITLE
Adjust power section styles.

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -2343,7 +2343,7 @@ radio > span.checked {
   font-weight: bold;
   text-align: center;
 }
-.spells .innatesphere-hidden[value|=S] ~ :not(.skillname-grid) {
+.spells .innatesphere-hidden[value|=S] ~ :not(.skillname-grid, .skillCP-grid) {
   opacity: 0;
   cursor: default;
   pointer-events: none;

--- a/bin/main.css
+++ b/bin/main.css
@@ -581,6 +581,27 @@ radio > span.checked {
   margin-bottom: 6px;
   background: linear-gradient(to top, rgba(194, 148, 91, 0.5019607843) 0%, transparent 100%);
 }
+.top-section .power-depth-cp-tp-section {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.top-section .power-depth-cp-tp-section input.TP {
+  width: 2ch;
+}
+.top-section .attributecontrol[value=basic] ~ span.attribute-value,
+.top-section .attributecontrol[value=basic] ~ button.reset-total,
+.top-section .attributecontrol[value=basic] ~ .attribute-roll,
+.top-section .attributecontrol[value=basic] ~ .not-basic-tab,
+.top-section .cpcontrol[value=basic] ~ .not-basic-tab {
+  display: none;
+}
+.top-section .attributecontrol:not([value=basic]) ~ input.attribute-value,
+.top-section .attributecontrol:not([value=basic]) ~ button.reset-total .attributecontrol:not([value=basic]) ~ .CP,
+.top-section .attributecontrol:not([value=basic]) ~ .basic-tab-only,
+.top-section .cpcontrol:not([value=basic]) ~ .basic-tab-only {
+  display: none;
+}
 .top-section .attribute-row {
   display: flex;
   align-items: center;
@@ -762,22 +783,6 @@ radio > span.checked {
 }
 
 /* ----------- Tabs and what they control  ------------- */
-/* Attributes */
-.attributecontrol[value=basic] ~ span.attribute-value,
-.attributecontrol[value=basic] ~ button.reset-total,
-.attributecontrol[value=basic] ~ .attribute-roll,
-.attributecontrol[value=basic] ~ .not-basic-tab,
-.cpcontrol[value=basic] ~ .not-basic-tab {
-  display: none;
-}
-
-.attributecontrol:not([value=basic]) ~ input.attribute-value,
-.attributecontrol:not([value=basic]) ~ button.reset-total .attributecontrol:not([value=basic]) ~ .CP,
-.attributecontrol:not([value=basic]) ~ .basic-tab-only,
-.cpcontrol:not([value=basic]) ~ .basic-tab-only {
-  display: none;
-}
-
 /* Tabs */
 .characterviewer .nav-tabs > li:not(.active) {
   background: #faf2ec;

--- a/bin/main.html
+++ b/bin/main.html
@@ -77,30 +77,29 @@
 <div class="top-section">
   <!-- Left top section -->
   <div class="flex-stack space-between">
-    <!-- Power, CP, TP -->
-    <div class="top-left-section">
-      <input class="cpcontrol" name="attr_chosentab" type="hidden" value="basic" />
-      <div class="power larger inline bold right middle">Power Depth</div>
-      <!-- Power is editable in basic tab only -->
-      <span class="power larger left bold middle not-basic-tab" name="attr_power"> </span>
-      <input class="power medium bold middle basic-tab-only" name="attr_power" type="number" value="0" />
-      <div class="CP larger inline bold right middle">CP</div>
-      <input name="attr_distributed_CP" type="hidden" value="0" />
-      <div class="inline middle">
-        <input class="CP bold larger right narrow" name="attr_CPU" value="@{CP} + (@{distributed_CP})        -(@{attribute_CP})        -(@{advantage_total_CP})        -(@{feat_total_CP})        -(@{skill_total_CP})        -(@{arcane_total_CP})        -(@{innate_total_CP})" disabled="true" />
+    <div class="power-depth-cp-tp-section">
+      <div class="power-depth">
+        <input class="cpcontrol" name="attr_chosentab" type="hidden" value="basic" />
+        <div class="power larger inline bold right middle">Power Depth</div>
+        <!-- Power is editable in basic tab only -->
+        <span class="power larger left bold middle not-basic-tab" name="attr_power"></span>
+        <input class="power medium bold middle basic-tab-only" name="attr_power" type="number" value="0" />
       </div>
-      <div class="inline">/</div>
-      <!-- CP is editable in basic tab only -->
-      <span class="CP bold larger middle not-basic-tab" name="attr_CP"> </span>
-      <input class="CP bold larger medium middle basic-tab-only" name="attr_CP" type="number" value="25" />
-      &emsp;
-      <div class="TP larger inline bold right middle">TP</div>
-      <div class="inline middle">
-        <input class="TP bold larger right narrow" name="attr_TPU" value="@{TP}        - (@{skill_total_TP})        - (@{arcane_total_TP})" disabled="true" />
+      <div class="cp-section">
+        <input class="cpcontrol" name="attr_chosentab" type="hidden" value="basic" />
+        <input name="attr_distributed_CP" type="hidden" value="0" />
+        <div class="CP larger inline bold right middle">CP</div>
+        <input class="CP bold larger center narrow" name="attr_CPU" value="@{CP} + (@{distributed_CP})          -(@{attribute_CP})          -(@{advantage_total_CP})          -(@{feat_total_CP})          -(@{skill_total_CP})          -(@{arcane_total_CP})          -(@{innate_total_CP})" disabled="true" />
+        <span>/&nbsp;</span>
+        <!-- CP is editable in basic tab only -->
+        <span class="CP bold larger middle not-basic-tab" name="attr_CP"></span>
+        <input class="CP bold larger medium middle basic-tab-only" name="attr_CP" type="number" value="25" />
       </div>
-      <div class="inline big middle">/</div>
-      <div class="inline middle">
-        <span class="TP bold larger middle" name="attr_TP" value="2"></span>
+      <div class="tp-section">
+        <div class="TP larger inline bold right middle">TP</div>
+        <input class="TP bold larger center narrow" name="attr_TPU" value="@{TP}        - (@{skill_total_TP})        - (@{arcane_total_TP})" disabled="true" />
+        <span>/&nbsp;</span>
+        <span class="TP bold larger middle center" name="attr_TP" value="2"></span>
       </div>
     </div>
 

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -115,7 +115,7 @@ $notes-popover-width: 16px;
       font-weight: bold;
       text-align: center;
     }
-    ~:not(.skillname-grid) {
+    ~:not(.skillname-grid, .skillCP-grid) {
       opacity: 0;
       cursor: default;
       pointer-events: none;

--- a/ui/tabs/tabs.scss
+++ b/ui/tabs/tabs.scss
@@ -1,22 +1,5 @@
 /* ----------- Tabs and what they control  ------------- */
 
-/* Attributes */
-
-.attributecontrol[value="basic"]~span.attribute-value,
-.attributecontrol[value="basic"]~button.reset-total,
-.attributecontrol[value="basic"]~.attribute-roll,
-.attributecontrol[value="basic"]~.not-basic-tab,
-.cpcontrol[value="basic"]~.not-basic-tab {
-  display: none;
-}
-
-.attributecontrol:not([value="basic"])~input.attribute-value,
-.attributecontrol:not([value="basic"])~button.reset-total .attributecontrol:not([value="basic"])~.CP,
-.attributecontrol:not([value="basic"])~.basic-tab-only,
-.cpcontrol:not([value="basic"])~.basic-tab-only {
-  display: none;
-}
-
 /* Tabs */
 .characterviewer .nav-tabs>li:not(.active) {
   background: $unselected-tab-color;

--- a/ui/topSection/topSection.pug
+++ b/ui/topSection/topSection.pug
@@ -3,37 +3,35 @@
 .top-section
   // Left top section 
   .flex-stack.space-between
-    // Power, CP, TP 
-    .top-left-section
-      input.cpcontrol(name='attr_chosentab' type='hidden' value='basic')
-      .power.larger.inline.bold.right.middle Power Depth
-      // Power is editable in basic tab only 
-      span.power.larger.left.bold.middle.not-basic-tab(name='attr_power')  
-      input.power.medium.bold.middle.basic-tab-only(name='attr_power' type='number' value='0')
-      .CP.larger.inline.bold.right.middle CP
-      input(name='attr_distributed_CP' type='hidden' value='0')
-      .inline.middle
-        input.CP.bold.larger.right.narrow(name='attr_CPU' value='@{CP} + (@{distributed_CP})\
-        -(@{attribute_CP})\
-        -(@{advantage_total_CP})\
-        -(@{feat_total_CP})\
-        -(@{skill_total_CP})\
-        -(@{arcane_total_CP})\
-        -(@{innate_total_CP})' disabled='true')
-      .inline /
-      // CP is editable in basic tab only 
-      span.CP.bold.larger.middle.not-basic-tab(name='attr_CP')  
-      input.CP.bold.larger.medium.middle.basic-tab-only(name='attr_CP' type='number' value='25')
-      = '\n'
-      | &emsp;
-      .TP.larger.inline.bold.right.middle TP
-      .inline.middle
-        input.TP.bold.larger.right.narrow(name='attr_TPU' value='@{TP}\
+    .power-depth-cp-tp-section
+      .power-depth
+        input.cpcontrol(name='attr_chosentab' type='hidden' value='basic')
+        .power.larger.inline.bold.right.middle Power Depth
+        // Power is editable in basic tab only 
+        span.power.larger.left.bold.middle.not-basic-tab(name='attr_power')
+        input.power.medium.bold.middle.basic-tab-only(name='attr_power' type='number' value='0')
+      .cp-section
+        input.cpcontrol(name='attr_chosentab' type='hidden' value='basic')
+        input(name='attr_distributed_CP' type='hidden' value='0')
+        .CP.larger.inline.bold.right.middle CP
+        input.CP.bold.larger.center.narrow(name='attr_CPU' value='@{CP} + (@{distributed_CP})\
+          -(@{attribute_CP})\
+          -(@{advantage_total_CP})\
+          -(@{feat_total_CP})\
+          -(@{skill_total_CP})\
+          -(@{arcane_total_CP})\
+          -(@{innate_total_CP})' disabled='true')
+        span /&nbsp;
+        // CP is editable in basic tab only 
+        span.CP.bold.larger.middle.not-basic-tab(name='attr_CP')
+        input.CP.bold.larger.medium.middle.basic-tab-only(name='attr_CP' type='number' value='25')
+      .tp-section
+        .TP.larger.inline.bold.right.middle TP
+        input.TP.bold.larger.center.narrow(name='attr_TPU' value='@{TP}\
         - (@{skill_total_TP})\
         - (@{arcane_total_TP})' disabled='true')
-      .inline.big.middle /
-      .inline.middle
-        span.TP.bold.larger.middle(name='attr_TP' value='2')
+        span /&nbsp;
+        span.TP.bold.larger.middle.center(name='attr_TP' value='2')
     = '\n'
     // IQ, DX, BR 
     //

--- a/ui/topSection/topSection.scss
+++ b/ui/topSection/topSection.scss
@@ -6,6 +6,30 @@
   border-bottom: solid black 1px;
   margin-bottom: 6px;
   background: linear-gradient(to top, $paper-gradient-color 0%, transparent 100%);
+  .power-depth-cp-tp-section {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    input.TP {
+      width: 2ch;
+    }
+  }
+
+  .attributecontrol[value="basic"]~span.attribute-value,
+  .attributecontrol[value="basic"]~button.reset-total,
+  .attributecontrol[value="basic"]~.attribute-roll,
+  .attributecontrol[value="basic"]~.not-basic-tab,
+  .cpcontrol[value="basic"]~.not-basic-tab {
+    display: none;
+  }
+
+  .attributecontrol:not([value="basic"])~input.attribute-value,
+  .attributecontrol:not([value="basic"])~button.reset-total .attributecontrol:not([value="basic"])~.CP,
+  .attributecontrol:not([value="basic"])~.basic-tab-only,
+  .cpcontrol:not([value="basic"])~.basic-tab-only {
+    display: none;
+  }
+
   .attribute-row {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Fix #77
A bit tricky to work for all cases, since input widths are fixed. Adjusted to

| Old | New |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/5629800/215366219-353f6229-e1f1-4811-9133-6f8119466425.png) | ![image](https://user-images.githubusercontent.com/5629800/215366223-bd6f5d98-1d33-4ad2-81df-73fbecbebf23.png) | | ![image](https://user-images.githubusercontent.com/5629800/215365832-f4d5974d-3442-4653-9e3c-31e04d08e955.png) | ![image](https://user-images.githubusercontent.com/5629800/215365838-6fc647ef-ff3a-413e-bbd7-027cffe5ba2c.png) |

Also:
Make CP field visible for all rows.

Fix The CP field should still be present for Innate spell spheres #75
![image](https://user-images.githubusercontent.com/5629800/215367070-318e194a-76cc-4193-89ce-a8346bdd0f79.png)
