### PR TITLE
Fix a few issues related to creating a new character

### DIFF
--- a/bin/main.html
+++ b/bin/main.html
@@ -1963,7 +1963,10 @@ const updateCopiedAbilities = function () {
         }
         update[skill.replace(' ', '_')] = ability;
       }
-      setAttrs(update);
+      setAttrs(update, () => {
+        log('updateArmorValue');
+        updateArmorValue();
+      });
     });
   });
 };
@@ -1971,7 +1974,8 @@ on('change:repeating_skill:skilldisciplineinfo' +
     ' change:repeating_skill:skillexpertise' +
     ' change:repeating_skill:skillability' +
     ' change:repeating_skill:skillname' +
-    ' change:DX change:weight_penalty sheet:opened remove:repeating_skill',
+    ' change:DX change:weight_penalty remove:repeating_skill' +
+    ' sheet:opened',
 updateCopiedAbilities);
 
 // skilldisciplineexpertise holds the expertise of the discipline that
@@ -2154,6 +2158,15 @@ on('remove:repeating_skill',
   });
 
 // -------------- Equipment -------------
+
+function getValidNumber(stringValue) {
+  const value = Number(stringValue);
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return value;
+}
+
 function getLargestWeaponDefense(callback) {
   getSectionIDs('weapon', function (ids) {
     const defenseFields = ids.map(
@@ -2162,8 +2175,8 @@ function getLargestWeaponDefense(callback) {
       id => `repeating_weapon_${id}_weaponcount`);
     getAttrs([...defenseFields, ...countFields], function (values) {
       const largestWeaponDefense = defenseFields.reduce((memo, defenseFieldName, i) => {
-        const defense = Number(values[defenseFieldName]);
-        const count = Number(values[countFields[i]]);
+        const defense = getValidNumber(values[defenseFieldName]);
+        const count = getValidNumber(values[countFields[i]]);
         if (defense > 0 && count > 0) {
           return Math.max(memo, defense);
         }
@@ -2184,9 +2197,9 @@ const updateArmorValue = function () {
   getLargestWeaponDefense((largestWeaponDefense) => {
     getAttrs([armorName, shieldName, defenseBoostName, defendName, reactionPenaltyName],
       function(values) {
-        const cur_armor = Number(values[armorName]);
-        const cur_shield = Number(values[shieldName]);
-        const cur_defend = Number(values[defendName]);
+        const cur_armor = getValidNumber(values[armorName]);
+        const cur_shield = getValidNumber(values[shieldName]);
+        const cur_defend = getValidNumber(values[defendName]);
         const update = {};
         for (let defense of ['dodge', 'block', 'parry']) {
           const defenseIsArmor = defense === 'dodge';
@@ -2196,14 +2209,14 @@ const updateArmorValue = function () {
             cur_defend
             + (defenseIsBlock ? cur_shield : 0)
             + (defenseIsParry ? largestWeaponDefense : 0)
-            - Math.abs(Number(values[reactionPenaltyName]))
+            - Math.abs(getValidNumber(values[reactionPenaltyName]))
           );
-          const total = base + Number(values['defense_boost']);
+          const total = base + getValidNumber(values['defense_boost']);
           /**
            * Block is only valid if there is a shield value.
            */
-          const blockIsValid = defenseIsBlock && cur_shield && !Number.isNaN(cur_shield);
-          const parryIsValid = defenseIsParry && largestWeaponDefense && !Number.isNaN(largestWeaponDefense);
+          const blockIsValid = defenseIsBlock && cur_shield;
+          const parryIsValid = defenseIsParry && largestWeaponDefense;
           const defenseIsValid = defenseIsArmor || blockIsValid || parryIsValid;
           update[`current_${defense}_without_armor`] = defenseIsValid ? String(total) : '--';
           update[`current_${defense}_with_armor`] = defenseIsValid ? String(total + cur_armor) : '--';

--- a/bin/main.html
+++ b/bin/main.html
@@ -1964,7 +1964,6 @@ const updateCopiedAbilities = function () {
         update[skill.replace(' ', '_')] = ability;
       }
       setAttrs(update, () => {
-        log('updateArmorValue');
         updateArmorValue();
       });
     });

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -848,7 +848,6 @@ const updateCopiedAbilities = function () {
         update[skill.replace(' ', '_')] = ability;
       }
       setAttrs(update, () => {
-        log('updateArmorValue');
         updateArmorValue();
       });
     });

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -847,7 +847,10 @@ const updateCopiedAbilities = function () {
         }
         update[skill.replace(' ', '_')] = ability;
       }
-      setAttrs(update);
+      setAttrs(update, () => {
+        log('updateArmorValue');
+        updateArmorValue();
+      });
     });
   });
 };
@@ -855,7 +858,8 @@ on('change:repeating_skill:skilldisciplineinfo' +
     ' change:repeating_skill:skillexpertise' +
     ' change:repeating_skill:skillability' +
     ' change:repeating_skill:skillname' +
-    ' change:DX change:weight_penalty sheet:opened remove:repeating_skill',
+    ' change:DX change:weight_penalty remove:repeating_skill' +
+    ' sheet:opened',
 updateCopiedAbilities);
 
 // skilldisciplineexpertise holds the expertise of the discipline that
@@ -1038,6 +1042,15 @@ on('remove:repeating_skill',
   });
 
 // -------------- Equipment -------------
+
+function getValidNumber(stringValue) {
+  const value = Number(stringValue);
+  if (Number.isNaN(value)) {
+    return 0;
+  }
+  return value;
+}
+
 function getLargestWeaponDefense(callback) {
   getSectionIDs('weapon', function (ids) {
     const defenseFields = ids.map(
@@ -1046,8 +1059,8 @@ function getLargestWeaponDefense(callback) {
       id => `repeating_weapon_${id}_weaponcount`);
     getAttrs([...defenseFields, ...countFields], function (values) {
       const largestWeaponDefense = defenseFields.reduce((memo, defenseFieldName, i) => {
-        const defense = Number(values[defenseFieldName]);
-        const count = Number(values[countFields[i]]);
+        const defense = getValidNumber(values[defenseFieldName]);
+        const count = getValidNumber(values[countFields[i]]);
         if (defense > 0 && count > 0) {
           return Math.max(memo, defense);
         }
@@ -1068,9 +1081,9 @@ const updateArmorValue = function () {
   getLargestWeaponDefense((largestWeaponDefense) => {
     getAttrs([armorName, shieldName, defenseBoostName, defendName, reactionPenaltyName],
       function(values) {
-        const cur_armor = Number(values[armorName]);
-        const cur_shield = Number(values[shieldName]);
-        const cur_defend = Number(values[defendName]);
+        const cur_armor = getValidNumber(values[armorName]);
+        const cur_shield = getValidNumber(values[shieldName]);
+        const cur_defend = getValidNumber(values[defendName]);
         const update = {};
         for (let defense of ['dodge', 'block', 'parry']) {
           const defenseIsArmor = defense === 'dodge';
@@ -1080,14 +1093,14 @@ const updateArmorValue = function () {
             cur_defend
             + (defenseIsBlock ? cur_shield : 0)
             + (defenseIsParry ? largestWeaponDefense : 0)
-            - Math.abs(Number(values[reactionPenaltyName]))
+            - Math.abs(getValidNumber(values[reactionPenaltyName]))
           );
-          const total = base + Number(values['defense_boost']);
+          const total = base + getValidNumber(values['defense_boost']);
           /**
            * Block is only valid if there is a shield value.
            */
-          const blockIsValid = defenseIsBlock && cur_shield && !Number.isNaN(cur_shield);
-          const parryIsValid = defenseIsParry && largestWeaponDefense && !Number.isNaN(largestWeaponDefense);
+          const blockIsValid = defenseIsBlock && cur_shield;
+          const parryIsValid = defenseIsParry && largestWeaponDefense;
           const defenseIsValid = defenseIsArmor || blockIsValid || parryIsValid;
           update[`current_${defense}_without_armor`] = defenseIsValid ? String(total) : '--';
           update[`current_${defense}_with_armor`] = defenseIsValid ? String(total + cur_armor) : '--';


### PR DESCRIPTION
Fix If a character has no Defend skill, their Block ability is coming up as Nan. #78

When creating a new character, the dodge should be calculated correctly.
Extract a utility to ensure numbers are valid.
Add a callback to ensure that after `defend` is updated, then so is `defense`
See:
https://wiki.roll20.net/Sheet_Worker_Scripts#setAttrs.28values.2Coptions.2Ccallback.29

When `setAttrs` is called, it doesn't trigger `change` listeners. (Probably to protect from circular or infinite loops).
`setAttrs` does have a `callback` function, and I use that to fix the issue.