### PR TITLE
Auto format and fix lint issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,5 +32,6 @@ module.exports = {
     }],
     'no-undef': 'off',
     'no-var': 'error',
+    eqeqeq: 'error',
   },
 };

--- a/bin/main.html
+++ b/bin/main.html
@@ -1116,11 +1116,11 @@ its value is used for css selection of its siblings.
 <script type="text/worker">
   'use strict';
 // ----- Utilities -----
-const removeNonNumeric = function(s) {
+const removeNonNumeric = function (s) {
   return String(s).trim().replace(/[^\d.-]/g, '');
 };
 
-const convertToFloat = function(s) {
+const convertToFloat = function (s) {
   let str = removeNonNumeric(s);
   if (!str) {
     return 0;
@@ -1134,32 +1134,32 @@ const convertToFloat = function(s) {
   }
 };
 
-const roundToTwoPlaces = function(s) {
-  return Math.floor(s*100)/100;
+const roundToTwoPlaces = function (s) {
+  return Math.floor(s * 100) / 100;
 };
 
-const sumValues = function(value_map) {
+const sumValues = function (value_map) {
   return Object.values(value_map).reduce(
     (accum, b) => accum + convertToFloat(b), 0);
 };
 
-const sumSingleValues = function(value_map) {
+const sumSingleValues = function (value_map) {
   return Object.values(value_map).reduce(
     (accum, b) => accum + (convertToFloat(b) === 1 ? 1 : 0),
     0);
 };
 
-const isEmptyValue = function(value) {
+const isEmptyValue = function (value) {
   return value === undefined || value.trim() === '';
 };
 
 // Add up the total cost for repeating_<section>:<name>TP
 // and put it in <section>_total_TP
-const updateTotalTP = function(section, name) {
+const updateTotalTP = function (section, name) {
   if (name === undefined) { name = section; }
-  getSectionIDs(section, function(ids) {
+  getSectionIDs(section, function (ids) {
     let TP_fields = ids.map(id => `repeating_${section}_${id}_${name}TP`);
-    getAttrs(TP_fields, function(tps) {
+    getAttrs(TP_fields, function (tps) {
       let update = {};
       update[section + '_total_TP'] = sumValues(tps);
       setAttrs(update);
@@ -1169,18 +1169,18 @@ const updateTotalTP = function(section, name) {
 
 // We record the number of CP costs of 1. This adds them all up,
 // and subtracts as many of them from the total as breadth allows.
-const updateDistributedCP = function() {
+const updateDistributedCP = function () {
   const feat = 'feat_total_single_CP';
   const skill = 'skill_total_single_CP';
   const arcane = 'arcane_total_single_CP';
   const innate = 'innate_total_single_CP';
   const tp = 'TP';
-  getAttrs([feat, skill, arcane, innate, tp], 
-    function(singles) {
+  getAttrs([feat, skill, arcane, innate, tp],
+    function (singles) {
       const total = (Number(singles[feat])
-              + Number(singles[skill])
-              + Number(singles[arcane])
-              + Number(singles[innate]));
+        + Number(singles[skill])
+        + Number(singles[arcane])
+        + Number(singles[innate]));
       // log("inputs: " + "'" + singles[advantage] 
       //                + "' '" + singles[feat]
       //                + "' '" + singles[skill]
@@ -1188,24 +1188,24 @@ const updateDistributedCP = function() {
       //                + "' '" + singles[innate] + "'");
       // log("Distributed: " + Math.min(total, Math.min(singles[tp], 6)
       //     + "  " + total);
-      setAttrs({'distributed_CP': Math.min(total, Math.min(singles[tp], 6))});
+      setAttrs({ 'distributed_CP': Math.min(total, Math.min(singles[tp], 6)) });
     });
 };
 
 on('change:tp' +
-      ' change:feat_total_single_CP' +
-      ' change:skill_total_single_CP' +
-      ' change:arcane_total_single_CP' +
-      ' change:innate_total_single_CP',
-updateDistributedCP);  
+  ' change:feat_total_single_CP' +
+  ' change:skill_total_single_CP' +
+  ' change:arcane_total_single_CP' +
+  ' change:innate_total_single_CP',
+updateDistributedCP);
 
 // Add up the total cost for repeating_<section>:<name>CP
 // and put it in <section>_total_CP
-const updateTotalCP = function(section, name) {
+const updateTotalCP = function (section, name) {
   if (name === undefined) { name = section; }
-  getSectionIDs(section, function(ids) {
+  getSectionIDs(section, function (ids) {
     let CP_fields = ids.map(id => `repeating_${section}_${id}_${name}CP`);
-    getAttrs(CP_fields, function(cps) {
+    getAttrs(CP_fields, function (cps) {
       let update = {};
       update[section + '_total_CP'] = sumValues(cps);
       update[section + '_total_single_CP'] = sumSingleValues(cps);
@@ -1230,11 +1230,11 @@ const getSectionIDsOrdered = function (sectionName, callback) {
 
 // ----- Top action and roll -----
 
-const toggleSavePending = function() {
+const toggleSavePending = function () {
   getAttrs(['save_pending'],
-    function(values) {
+    function (values) {
       let new_value = Number(values['save_pending']) ? 0 : 1;
-      setAttrs({'save_pending': new_value});
+      setAttrs({ 'save_pending': new_value });
     });
 };
 on('clicked:saveroll', toggleSavePending);
@@ -1245,11 +1245,13 @@ const roll_keys = ['action_description', 'action_feats',
   'roll_mod1', 'roll_mod2', 'roll_mod3',
   'roll_advance_boost'];
 
-const saveRollState = function(key, roll_chosen) {
+const saveRollState = function (key, roll_chosen) {
   getAttrs(roll_keys,
-    function(values) {
-      let update = {'save_pending': 0,
-        'roll_chosen': roll_chosen};
+    function (values) {
+      let update = {
+        'save_pending': 0,
+        'roll_chosen': roll_chosen
+      };
       // We write the values in a fixed order, so we can do equality
       // checks.
       update[key] = JSON.stringify(values, roll_keys);
@@ -1257,10 +1259,10 @@ const saveRollState = function(key, roll_chosen) {
     });
 };
 
-const loadRollState = function(key, roll_chosen) {
+const loadRollState = function (key, roll_chosen) {
   getAttrs([key],
-    function(values) {
-      if (values[key] != '') {
+    function (values) {
+      if (values[key] !== '') {
         let change = JSON.parse(values[key]);
         change['roll_chosen'] = roll_chosen;
         setAttrs(change);
@@ -1271,16 +1273,16 @@ const loadRollState = function(key, roll_chosen) {
     });
 };
 
-const checkRollChosen = function() {
-  getAttrs(['roll_chosen'], function(values) {
+const checkRollChosen = function () {
+  getAttrs(['roll_chosen'], function (values) {
     let roll_chosen = Number(values['roll_chosen']);
     if (roll_chosen) {
       let saved_roll = 'saved_roll_' + roll_chosen;
-      getAttrs(roll_keys.concat([saved_roll]), function(values) {
+      getAttrs(roll_keys.concat([saved_roll]), function (values) {
         let saved = values[saved_roll];
         let current = JSON.stringify(values, roll_keys);
-        if (saved != current) {
-          setAttrs({'roll_chosen': ''});
+        if (saved !== current) {
+          setAttrs({ 'roll_chosen': '' });
         }
       });
     }
@@ -1288,9 +1290,9 @@ const checkRollChosen = function() {
 };
 on(roll_keys.map(name => 'change:' + name).join(' '), checkRollChosen);
 
-const doChooseRoll = function(number) {
+const doChooseRoll = function (number) {
   let saved_roll = 'saved_roll_' + number;
-  getAttrs(['save_pending'], function(values) {
+  getAttrs(['save_pending'], function (values) {
     if (Number(values['save_pending'])) {
       saveRollState(saved_roll, number);
     } else {
@@ -1299,45 +1301,53 @@ const doChooseRoll = function(number) {
   });
 };
 const roll_choices = ['1', '2', '3', '4', '5', '6'];
-roll_choices.forEach(function(value) {
-  on(`clicked:choose_roll_${value}`, function() { doChooseRoll(value); });
+roll_choices.forEach(function (value) {
+  on(`clicked:choose_roll_${value}`, function () { doChooseRoll(value); });
 });
 
-const topActionDeltas = function(values) {
-  let action_feats =  Number(values['action_feats']);
+const topActionDeltas = function (values) {
+  let action_feats = Number(values['action_feats']);
   let feats_EP = action_feats;
   let action_EP = Number(values['action_EP']);
   let action_SP = Number(values['action_SP']);
-  return {'EPS': (action_feats != 0 ? [-feats_EP] : []).concat(
-    (action_EP != 0 ? [-action_EP] : [])),
-  'SPS': action_SP != 0 ? [-action_SP] : []};
+  return {
+    'EPS': (action_feats !== 0 ? [-feats_EP] : []).concat(
+      (action_EP !== 0 ? [-action_EP] : [])),
+    'SPS': action_SP !== 0 ? [-action_SP] : []
+  };
 };
 
-const topRollDeltas = function(values) {
-  let advance_boost =  Number(values['roll_advance_boost']);
+const topRollDeltas = function (values) {
+  let advance_boost = Number(values['roll_advance_boost']);
   let boost_EP = advance_boost;
-  return {'EPS': advance_boost != 0 ? [-boost_EP] : [],
-    'SPS': []};
+  return {
+    'EPS': advance_boost !== 0 ? [-boost_EP] : [],
+    'SPS': []
+  };
 };
 
-const addDeltas = function(deltas1, deltas2) {
-  return {'EPS': deltas1['EPS'].concat(deltas2['EPS']),
-    'SPS': deltas1['SPS'].concat(deltas2['SPS'])};
+const addDeltas = function (deltas1, deltas2) {
+  return {
+    'EPS': deltas1['EPS'].concat(deltas2['EPS']),
+    'SPS': deltas1['SPS'].concat(deltas2['SPS'])
+  };
 };
 
-const multiplyDeltas = function(deltas, multiplier) {
-  return {'EPS': deltas['EPS'].map(x => x * multiplier),
-    'SPS': deltas['SPS'].map(x => x * multiplier)};
+const multiplyDeltas = function (deltas, multiplier) {
+  return {
+    'EPS': deltas['EPS'].map(x => x * multiplier),
+    'SPS': deltas['SPS'].map(x => x * multiplier)
+  };
 };
 
-const modifiersToTotal = function(modifiers) {
+const modifiersToTotal = function (modifiers) {
   return modifiers.reduce((accum, modifier) => accum + modifier,
     0);
 };
 
-const modifiersToString = function(modifiers) {
-  return modifiers.reduce(function(accum, modifier) {
-    if (modifier == 0) {
+const modifiersToString = function (modifiers) {
+  return modifiers.reduce(function (accum, modifier) {
+    if (modifier === 0) {
       return accum;
     } else if (modifier > 0) {
       return accum + '+' + String(modifier);
@@ -1348,31 +1358,33 @@ const modifiersToString = function(modifiers) {
   '');
 };
 
-const isLegalUpdate = function(current, deltas) {
-  return (   (-modifiersToTotal(deltas['EPS']) <=  Number(current['EP_t']))
-          && (-modifiersToTotal(deltas['SPS']) <=  Number(current['SP'])));
+const isLegalUpdate = function (current, deltas) {
+  return ((-modifiersToTotal(deltas['EPS']) <= Number(current['EP_t']))
+    && (-modifiersToTotal(deltas['SPS']) <= Number(current['SP'])));
 };
 
-const makeUpdate = function(current, deltas) {
+const makeUpdate = function (current, deltas) {
   let EP_delta = modifiersToTotal(deltas['EPS']);
   const current_EP_t = Number(current['EP_t']);
   const EP_t_max = Number(current['EP_t_max']);
   const new_EP_t = Math.max(0, Math.min(EP_t_max * 2, current_EP_t + EP_delta));
   // log("EP_delta " + EP_delta + "  current_EP_t " + current_EP_t);
   // log("EP_t_max " + EP_t_max + "  new_EP_t" + new_EP_t);
-  return {'EP_t': new_EP_t,
-    'SP': Number(current['SP']) + modifiersToTotal(deltas['SPS'])};
+  return {
+    'EP_t': new_EP_t,
+    'SP': Number(current['SP']) + modifiersToTotal(deltas['SPS'])
+  };
 };
 
-const deltasDescription = function(deltas) {
+const deltasDescription = function (deltas) {
   let description = '';
   if (deltas['EPS'].length) {
     description = (description + ' ('
-                    + modifiersToString(deltas['EPS']) + ' EP)');
+      + modifiersToString(deltas['EPS']) + ' EP)');
   }
   if (deltas['SPS'].length) {
-    description = (description + ' (' 
-                    + modifiersToString(deltas['SPS']) + ' SP)');
+    description = (description + ' ('
+      + modifiersToString(deltas['SPS']) + ' SP)');
   }
   return description;
 };
@@ -1380,12 +1392,12 @@ const deltasDescription = function(deltas) {
 const doTopAction = function () {
   getAttrs(['EP_t', 'EP_t_max', 'SP',
     'action_description', 'action_feats',
-    'action_EP', 'action_SP'], 
-  function(values) {
+    'action_EP', 'action_SP'],
+  function (values) {
     let deltas = topActionDeltas(values);
     let update = makeUpdate(values, deltas);
-    update['pendingchat'] = (  values['action_description']
-                                + deltasDescription(deltas));
+    update['pendingchat'] = (values['action_description']
+        + deltasDescription(deltas));
     setAttrs(update);
   });
 };
@@ -1394,11 +1406,11 @@ on('clicked:topaction', doTopAction);
 const undoTopAction = function () {
   getAttrs(['EP_t', 'EP_t_max', 'SP',
     'action_feats', 'action_EP', 'action_SP'],
-  function(values) {
+  function (values) {
     let deltas = multiplyDeltas(topActionDeltas(values), -1);
     let update = makeUpdate(values, deltas);
     let restored = deltasDescription(deltas);
-    if (restored != '') {
+    if (restored !== '') {
       update['pendingchat'] = 'Undo restoring' + restored;
     }
     setAttrs(update);
@@ -1406,15 +1418,15 @@ const undoTopAction = function () {
 };
 on('clicked:undotopaction', undoTopAction);
 
-const topRollCommand = function(values) {
-  let ability =  Number(values['roll_ability']);
+const topRollCommand = function (values) {
+  let ability = Number(values['roll_ability']);
   let modifiers = [Number(values['roll_mod1']),
     Number(values['roll_mod2']),
     Number(values['roll_mod3']),
     Number(values['roll_advance_boost'])];
   let base = ability + modifiersToTotal(modifiers);
-  let description = (  values['roll_skill'] + ' '
-                      + String(ability) + modifiersToString(modifiers));
+  let description = (values['roll_skill'] + ' '
+    + String(ability) + modifiersToString(modifiers));
   return '!EPRoll ' + String(base) + ' Tries ' + description;
 };
 
@@ -1424,13 +1436,13 @@ const doTopRoll = function () {
     'action_EP', 'action_SP',
     'roll_skill', 'roll_ability',
     'roll_mod1', 'roll_mod2', 'roll_mod3', 'roll_advance_boost'],
-  function(values) {
+  function (values) {
     let deltas = addDeltas(topActionDeltas(values),
       topRollDeltas(values));
     let update = makeUpdate(values, deltas);
-    let description = ( values['action_description']
-                          + deltasDescription(deltas));
-    if (description != '') {
+    let description = (values['action_description']
+        + deltasDescription(deltas));
+    if (description !== '') {
       description = description + '\n';
     }
     update['pendingchat'] = description + topRollCommand(values);
@@ -1443,13 +1455,13 @@ const undoTopRoll = function () {
   getAttrs(['EP_t', 'EP_t_max', 'SP',
     'action_feats', 'action_EP', 'action_SP',
     'roll_advance_boost'],
-  function(values) {
+  function (values) {
     let deltas = multiplyDeltas(addDeltas(topActionDeltas(values),
       topRollDeltas(values)),
     -1);
     let update = makeUpdate(values, deltas);
     let restored = deltasDescription(deltas);
-    if (restored != '') {
+    if (restored !== '') {
       update['pendingchat'] = 'Undo restoring' + restored;
     }
     setAttrs(update);
@@ -1513,77 +1525,82 @@ const updateTopActEnables = function () {
   log('Updating top action enables');
   getAttrs(['EP_t', 'SP',
     'action_feats', 'action_EP', 'action_SP', 'roll_advance_boost'],
-  function(values) {
+  function (values) {
     let top_action_deltas = topActionDeltas(values);
     let top_roll_deltas = addDeltas(topActionDeltas(values),
       topRollDeltas(values));
     log(values);
     log(top_action_deltas);
-    let update = {'disable_do':
-                      isLegalUpdate(values, top_action_deltas) ? '0' : '1',
-    'disable_do_and_roll':
-                      isLegalUpdate(values, top_roll_deltas) ? '0' : '1'};
+    let update = {
+      'disable_do':
+          isLegalUpdate(values, top_action_deltas) ? '0' : '1',
+      'disable_do_and_roll':
+          isLegalUpdate(values, top_roll_deltas) ? '0' : '1'
+    };
     log(update);
     setAttrs(update);
   });
 };
 
 on('change:ep_t' +
-    ' change:sp' +
-    ' change:action_feats' +
-    ' change:action_ep' +
-    ' change:action_sp' +
-    ' change:roll_advance_boost',
+  ' change:sp' +
+  ' change:action_feats' +
+  ' change:action_ep' +
+  ' change:action_sp' +
+  ' change:roll_advance_boost',
 updateTopActEnables);
 
 // ----- EP_t, and SP ----
-const updateEP = function() {
+const updateEP = function () {
   const power = 'power';
   const EP_t_max = 'EP_t_max';
   const SP_max = 'SP_max';
-  getAttrs([power, EP_t_max, SP_max], function(values) {
+  getAttrs([power, EP_t_max, SP_max], function (values) {
     let power_v = Number(values[power]);
     const EP_t_max_v = Number(values[EP_t_max]);
     const SP_max_v = Number(values[SP_max]);
     const power_points = (power_v < 6 ?
       power_v :
-      Math.floor(5*(Math.sqrt(power_v - 1) - 1)));
+      Math.floor(5 * (Math.sqrt(power_v - 1) - 1)));
     const new_SP_max = Math.floor((power_points - 3 * EP_t_max_v) / 2);
     // We get called from spurrios changes to SP_max,
     // So only reset all the values if something actually changed.
     log('EP_t: ' + EP_t_max_v + '  SP: ' + SP_max_v
-          + '  new SP: ' + new_SP_max);
-    if (new_SP_max != SP_max_v) {
-      setAttrs({'EP_t': EP_t_max_v,
+      + '  new SP: ' + new_SP_max);
+    if (new_SP_max !== SP_max_v) {
+      setAttrs({
+        'EP_t': EP_t_max_v,
         'SP_max': new_SP_max,
-        'SP': new_SP_max});
+        'SP': new_SP_max
+      });
     }
   });
 };
 on('change:power change:ep_t_max', updateEP);
 
-const fixPower = function() {
+const fixPower = function () {
   const power = 'power';
   const EP_max = 'EP_max';
   const SP_max = 'SP_max';
-  getAttrs([power, EP_max, SP_max], function(values) {
+  getAttrs([power, EP_max, SP_max], function (values) {
     let power_v = Number(values[power]);
     const EP_max_v = Number(values[EP_max]);
     const SP_max_v = Number(values[SP_max]);
     // Set power to EP if we have an old sheet, where it wasn't set yet.
-    if (power_v == 0 && SP_max_v == 0 && EP_max_v > 0) {
+    if (power_v === 0 && SP_max_v === 0 && EP_max_v > 0) {
       power_v = EP_max_v;
     }
-    setAttrs({'power': power_v}, null, updateEP);
+    setAttrs({ 'power': power_v }, null, updateEP);
   });
 };
 on('sheet:opened', fixPower);
 
 // ----- Tab navigation -----
 ['overview', 'basic', 'equipment', 'skills', 'spells', 'notes'].forEach(
-  button => { on(`clicked:${button}`, function() {
-    setAttrs({chosentab: button});
-  });
+  button => {
+    on(`clicked:${button}`, function () {
+      setAttrs({ chosentab: button });
+    });
   });
 
 // ----- Popovers -----
@@ -1627,21 +1644,21 @@ function setupSpellNotes(spellDomain) {
 const updateTP = function () {
   const CP = 'CP';
   // const TP = 'TP';
-  getAttrs([CP], function(values) {
-    const TP_v = Math.floor(Number(values[CP])/10);
-    setAttrs({'TP': TP_v});
+  getAttrs([CP], function (values) {
+    const TP_v = Math.floor(Number(values[CP]) / 10);
+    setAttrs({ 'TP': TP_v });
   });
 };
 on('change:cp sheet:opened', updateTP);
 
 // ----- Attribute costs -----
-const updateAttributeCost = function() {
-  getAttrs(['IQ', 'DX', 'BR'], function(attributes) {
+const updateAttributeCost = function () {
+  getAttrs(['IQ', 'DX', 'BR'], function (attributes) {
     const IQ = Number(attributes.IQ);
     const DX = Number(attributes.DX);
     const BR = Number(attributes.BR);
     const total = IQ + DX + BR;
-    const total_squares = IQ**2 + DX**2 + BR**2;
+    const total_squares = IQ ** 2 + DX ** 2 + BR ** 2;
     let cost = '??';
     if (total === 3) {
       if (total_squares === 3) {
@@ -1652,8 +1669,10 @@ const updateAttributeCost = function() {
         cost = 10;
       }
     }
-    setAttrs({displayed_attribute_CP: String(cost),
-      attribute_CP: cost === '??' ? 0 : cost});
+    setAttrs({
+      displayed_attribute_CP: String(cost),
+      attribute_CP: cost === '??' ? 0 : cost
+    });
   });
 };
 on('change:iq change:dx change:br', updateAttributeCost);
@@ -1680,7 +1699,7 @@ const advantageCosts = {
 
 // Advantages used to be stored as _plus or _minus, rather than as _count.
 // Go through all of those, transfer them to _count, and eliminate them.
-const migrateAdvantages = function() {
+const migrateAdvantages = function () {
   const fixed_advantage_prefixes = Object.keys(advantageCosts).map(
     advantage => 'advantage_' + advantage + '_');
   const fixed_advantage_plus_fields = fixed_advantage_prefixes.map(
@@ -1688,13 +1707,13 @@ const migrateAdvantages = function() {
   const fixed_advantage_minus_fields = fixed_advantage_prefixes.map(
     prefix => prefix + 'minus');
   getAttrs(fixed_advantage_plus_fields.concat(fixed_advantage_minus_fields),
-    function(attributes) {
+    function (attributes) {
       const update = {};
       for (const advantage of Object.keys(advantageCosts)) {
         const prefix = 'advantage_' + advantage + '_';
         for (const polarity of ['plus', 'minus']) {
-          if (Number(attributes[prefix + polarity]) == 1) {
-            update[prefix + 'count'] = polarity == 'plus' ? '1' : '-1';
+          if (Number(attributes[prefix + polarity]) === 1) {
+            update[prefix + 'count'] = polarity === 'plus' ? '1' : '-1';
             update[prefix + polarity] = '0';
           }
         }
@@ -1714,7 +1733,7 @@ on('sheet:opened', migrateAdvantages);
 // how the cost of that advantage was computed.
 // Return the total of all the costs.
 // The order of the elements of the array may be changed by the function.
-const calculateAdvantageCosts = function(advantages) {
+const calculateAdvantageCosts = function (advantages) {
   log('Calculating');
   // Sort them from most expensive to least.
   advantages.sort(function (a, b) { return b.base_cost - a.base_cost; });
@@ -1727,13 +1746,13 @@ const calculateAdvantageCosts = function(advantages) {
       total_cost += -Math.floor(base_cost / 2);
       advantage.cost_description = '-' + String(base_cost) + '/2';
     } else if (count > 0) {
-      if (base_cost <= 0 ) {
+      if (base_cost <= 0) {
         total_cost += base_cost;
         advantage.cost_description = String(base_cost);
       } else {
-        const multiplier = (seen+1 + seen+count) * count / 2;
+        const multiplier = (seen + 1 + seen + count) * count / 2;
         total_cost += base_cost * multiplier;
-        if (multiplier == 1) {
+        if (multiplier === 1) {
           advantage.cost_description = String(base_cost);
         } else {
           advantage.cost_description = (
@@ -1755,13 +1774,13 @@ const updateAdvantagesCosts = function () {
     advantage => 'advantage_' + advantage + '_');
   const fixed_advantage_count_fields = fixed_advantage_prefixes.map(
     prefix => prefix + 'count');
-  getSectionIDs('extraadvantage', function(extra_ids) {
-    const extra_advantage_cost_fields =  extra_ids.map(
+  getSectionIDs('extraadvantage', function (extra_ids) {
+    const extra_advantage_cost_fields = extra_ids.map(
       id => 'repeating_extraadvantage_' + id + '_extraadvantageCP');
     getAttrs(fixed_advantage_count_fields.concat(extra_advantage_cost_fields),
-      function(attributes) {
+      function (attributes) {
         const fixed_advantages = Object.keys(advantageCosts).map(
-          function(advantage) {
+          function (advantage) {
             const prefix = 'advantage_' + advantage + '_';
             return {
               description_key: prefix + 'CPdescription',
@@ -1770,7 +1789,7 @@ const updateAdvantagesCosts = function () {
             };
           });
         const extra_advantages = extra_ids.map(
-          function(extra_id) {
+          function (extra_id) {
             const prefix = 'repeating_extraadvantage_' + extra_id + '_';
             return {
               description_key: prefix + 'extraadvantageCPdescription',
@@ -1780,7 +1799,7 @@ const updateAdvantagesCosts = function () {
           });
         const advantages = fixed_advantages.concat(extra_advantages);
         const total_cost = calculateAdvantageCosts(advantages);
-        const update = {advantage_total_CP: total_cost};
+        const update = { advantage_total_CP: total_cost };
         for (const advantage of advantages) {
           update[advantage.description_key] = advantage.cost_description;
         }
@@ -1794,62 +1813,64 @@ on(Object.keys(advantageCosts).map(
 ).join(' '),
 updateAdvantagesCosts);
 
-on((  'change:repeating_extraadvantage:extraadvantageCP'
-    + ' remove:repeating_extraadvantage'),
+on(('change:repeating_extraadvantage:extraadvantageCP'
+  + ' remove:repeating_extraadvantage'),
 updateAdvantagesCosts);
 
 const updateHPMax = function () {
   const BR = 'BR';
   const healthy = 'advantage_healthy_count';
-  getAttrs([BR, healthy], function(values) {
+  getAttrs([BR, healthy], function (values) {
     const effective_BR = (Number(values[BR])
-                      + Number(values[healthy]));
+      + Number(values[healthy]));
     const max_hp = (effective_BR <= -3 ?
       8 + effective_BR :
-      12 + effective_BR*(effective_BR+7)/2);
-    setAttrs({'HP_max': max_hp});
+      12 + effective_BR * (effective_BR + 7) / 2);
+    setAttrs({ 'HP_max': max_hp });
   });
 };
 on('change:br change:advantage_healthy_count' +
-    ' sheet:opened',
+  ' sheet:opened',
 updateHPMax);
 
-const reset_EP_t = function() {
+const reset_EP_t = function () {
   const EP_t = 'EP_t';
   const EP_t_max = 'EP_t_max';
-  getAttrs([EP_t, EP_t_max], function(values) {
+  getAttrs([EP_t, EP_t_max], function (values) {
     const EP_t_max_v = Number(values[EP_t_max]);
-    setAttrs({EP_t: EP_t_max_v + Math.min(EP_t_max_v, Number(values[EP_t]))});
+    setAttrs({ EP_t: EP_t_max_v + Math.min(EP_t_max_v, Number(values[EP_t])) });
   });
 };
 on('clicked:reset_ep_t', reset_EP_t);
 
-const convertSP = function() {
+const convertSP = function () {
   const EP_t = 'EP_t';
   const SP = 'SP';
-  getAttrs([EP_t, SP], function(attributes) {
+  getAttrs([EP_t, SP], function (attributes) {
     let EP_t_v = Number(attributes[EP_t]);
     let SP_v = Number(attributes[SP]);
     if (SP_v > 0) {
-      setAttrs({'EP_t': EP_t_v + 2,
-        'SP': SP_v - 1});
+      setAttrs({
+        'EP_t': EP_t_v + 2,
+        'SP': SP_v - 1
+      });
     }
   });
 };
 on('clicked:convert_sp', convertSP);
 
-const reset_SP = function() {
+const reset_SP = function () {
   const SP_max = 'SP_max';
-  getAttrs([SP_max], function(values) {
-    setAttrs({'SP': values[SP_max]});
+  getAttrs([SP_max], function (values) {
+    setAttrs({ 'SP': values[SP_max] });
   });
 };
 on('clicked:reset_sp', reset_SP);
 
-const reset_HP = function() {
+const reset_HP = function () {
   const HP_max = 'HP_max';
-  getAttrs([HP_max], function(values) {
-    setAttrs({'HP': values[HP_max]});
+  getAttrs([HP_max], function (values) {
+    setAttrs({ 'HP': values[HP_max] });
   });
 };
 on('clicked:reset_hp', reset_HP);
@@ -1858,11 +1879,11 @@ on('clicked:reset_hp', reset_HP);
 // ----- Epic Feats -----
 
 // Set E for extraordinary
-on('change:repeating_feat:featextraordinary', function() {
+on('change:repeating_feat:featextraordinary', function () {
   getAttrs(['repeating_feat_featextraordinary'], function (values) {
     const letter = (
       values.repeating_feat_featextraordinary === '1' ? 'E' : ' ');
-    setAttrs({'repeating_feat_featextraordinaryletter': letter});
+    setAttrs({ 'repeating_feat_featextraordinaryletter': letter });
   });
 });
 
@@ -1872,18 +1893,18 @@ on('change:repeating_feat:featcp remove:repeating_feat',
 // Set default CP cost
 // There is no event for a row being added, so new rows start out with
 // empty cost. Then we set it to the usual 4 when a feat name is entered.
-on('change:repeating_feat:featname', function(event) {
+on('change:repeating_feat:featname', function (event) {
   let prev_name = event.previousValue;
   const new_name = event.newValue;
   // When a new row is filled in for the first time, previousValue
   // comes back as the new value.
-  if (prev_name == new_name) { prev_name = undefined; }
+  if (prev_name === new_name) { prev_name = undefined; }
   if (isEmptyValue(prev_name) !== isEmptyValue(new_name)) {
     let field_name_parts = event.sourceAttribute.split('_');
     field_name_parts.pop();
     field_name_parts.push('featCP');
     const CP_field = field_name_parts.join('_');
-    getAttrs([field_name_parts.join('_')], function(values) {
+    getAttrs([field_name_parts.join('_')], function (values) {
       const prev_CP_cost = values[CP_field];
       if (isEmptyValue(prev_CP_cost) === isEmptyValue(prev_name)) {
         let default_value = {};
@@ -1903,7 +1924,7 @@ function isValueDefined(value) {
 const updateCopiedAbilities = function () {
   const DX = 'DX';
   const weight_penalty = 'weight_penalty';
-  getSectionIDsOrdered('skill', function(ids) {
+  getSectionIDsOrdered('skill', function (ids) {
     const disciplineinfos = ids.map(
       id => `repeating_skill_${id}_skilldisciplineinfo`);
     const expertises = ids.map(
@@ -1914,7 +1935,7 @@ const updateCopiedAbilities = function () {
       id => `repeating_skill_${id}_skillname`);
     getAttrs(disciplineinfos.concat(expertises)
       .concat(abilities).concat(names)
-      .concat([DX, weight_penalty]), function(values) {
+      .concat([DX, weight_penalty]), function (values) {
       const DX_n = Number(values[DX]);
       const weight_penalty_n = Number(values[weight_penalty]);
       // Make a map from skill names to their index.
@@ -1931,7 +1952,7 @@ const updateCopiedAbilities = function () {
           const discipline_index = skill_map[discipline];
           const expertise_v = values[expertises[discipline_index]];
           if (values[disciplineinfos[discipline_index]] === 'D'
-                && expertise_v !== '--') {
+              && expertise_v !== '--') {
             min_expertise = -2 + Number(expertise_v);
           }
         }
@@ -1946,7 +1967,7 @@ const updateCopiedAbilities = function () {
           skill === 'spell touch' ?
             min_expertises['attack'] + 4 :
             Math.max(min_expertises['defense'],
-              min_expertises['defend'])- 3);
+              min_expertises['defend']) - 3);
         let skill_index = skill_map[skill];
         if (isValueDefined(skill_index) && values[disciplineinfos[skill_index]] === 'D') {
           skill_index = null;
@@ -1973,11 +1994,11 @@ const updateCopiedAbilities = function () {
   });
 };
 on('change:repeating_skill:skilldisciplineinfo' +
-    ' change:repeating_skill:skillexpertise' +
-    ' change:repeating_skill:skillability' +
-    ' change:repeating_skill:skillname' +
-    ' change:DX change:weight_penalty remove:repeating_skill' +
-    ' sheet:opened',
+  ' change:repeating_skill:skillexpertise' +
+  ' change:repeating_skill:skillability' +
+  ' change:repeating_skill:skillname' +
+  ' change:DX change:weight_penalty remove:repeating_skill' +
+  ' sheet:opened',
 updateCopiedAbilities);
 
 // skilldisciplineexpertise holds the expertise of the discipline that
@@ -1985,7 +2006,7 @@ updateCopiedAbilities);
 // note which are disciplines, and set the discipline expertise of
 // all skills to that of the most recent discipline we encountered.
 const updateSkillDisciplineExpertises = function (section) {
-  getSectionIDsOrdered(section, function(ids) {
+  getSectionIDsOrdered(section, function (ids) {
     const disciplineinfos = ids.map(
       id => `repeating_${section}_${id}_skilldisciplineinfo`);
     const isdisciplines = ids.map(
@@ -1996,18 +2017,18 @@ const updateSkillDisciplineExpertises = function (section) {
       id => `repeating_${section}_${id}_skilldisciplineexpertise`);
     getAttrs(disciplineinfos.concat(isdisciplines).concat(expertises)
       .concat(disciplineexpertises),
-    function(attributes) {
+    function (attributes) {
       let discipline_expertise = 0;
       let update = {};
       for (let i = 0; i < ids.length; ++i) {
         if (attributes[disciplineinfos[i]] === 'D') {
           discipline_expertise = attributes[expertises[i]];
-          if (attributes[isdisciplines[i]] != 1) {
-            update[isdisciplines[i]] = 1;
+          if (attributes[isdisciplines[i]] !== '1') {
+            update[isdisciplines[i]] = '1';
           }
         } else {
-          if (attributes[isdisciplines[i]] != 0) {
-            update[isdisciplines[i]] = 0;
+          if (attributes[isdisciplines[i]] !== '0') {
+            update[isdisciplines[i]] = '0';
           }
           let this_discipline_expertise = 0;
           if (attributes[disciplineinfos[i]] === '⇡') {
@@ -2018,14 +2039,14 @@ const updateSkillDisciplineExpertises = function (section) {
           }
         }
       }
-      if (! _.isEmpty(update)) {
+      if (!_.isEmpty(update)) {
         setAttrs(update);
       }
     });
   });
 };
 
-const updateSkillDerivedForId = function(section, row_id) {
+const updateSkillDerivedForId = function (section, row_id) {
   const name = `repeating_${section}_${row_id}_skillname`;
   const disciplineinfo = `repeating_${section}_${row_id}_skilldisciplineinfo`;
   const expertise = `repeating_${section}_${row_id}_skillexpertise`;
@@ -2040,7 +2061,7 @@ const updateSkillDerivedForId = function(section, row_id) {
   const devout = 'advantage_devout_count';
   getAttrs([name, disciplineinfo, expertise, disciplineexpertise,
     attribute, base, 'IQ', 'DX', mage, devout],
-  function(values) {
+  function (values) {
     // Update TP and CP costs
     let update = {};
     if (values[disciplineinfo] === 'D') {
@@ -2062,7 +2083,7 @@ const updateSkillDerivedForId = function(section, row_id) {
       update[tp] = cost === 0 ? ' ' : cost;
       update[cp] = ' ';
       // Fix illegal values for expertise of discipline.
-      if ({'ST': true, '-1': true, '0': true}[values[expertise]]) {
+      if ({ 'ST': true, '-1': true, '0': true }[values[expertise]]) {
         update[expertise] = '--';
       }
     } else {
@@ -2084,7 +2105,7 @@ const updateSkillDerivedForId = function(section, row_id) {
       update[tp] = ' ';
       update[cp] = cost === 0 ? ' ' : cost;
       // Clear base if it is 0.
-      if (values[base] == '0') {
+      if (values[base] === '0') {
         update[base] = ' ';
       }
       // Update ability
@@ -2095,12 +2116,12 @@ const updateSkillDerivedForId = function(section, row_id) {
         Number(disciplineexpertise_v));
       const IQ_n = Number(values['IQ']);
       const DX_n = Number(values['DX']);
-      if (attribute_v == '') {
+      if (attribute_v === '') {
         update[ability] = '??';
       } else {
         update[ability] = (
-          (attribute_v == 'IQ' ? IQ_n :
-            attribute_v == 'DX' ? DX_n :
+          (attribute_v === 'IQ' ? IQ_n :
+            attribute_v === 'DX' ? DX_n :
               IQ_n + DX_n) +
             (section === 'arcane' ?
               Number(values[mage]) * 2 :
@@ -2109,7 +2130,7 @@ const updateSkillDerivedForId = function(section, row_id) {
                 0) +
             Number(values[base]) +
             disciplineexpertise_n +
-            (expertise_v == 'ST' ? -1 :
+            (expertise_v === 'ST' ? -1 :
               expertise_v !== '--' ? Number(expertise_v) :
                 disciplineexpertise_n === 0 ? -5 : -2));
       }
@@ -2118,7 +2139,7 @@ const updateSkillDerivedForId = function(section, row_id) {
   });
 };
 
-const updateSkillDerived = function(section, event) {
+const updateSkillDerived = function (section, event) {
   const row_id = event.sourceAttribute.split('_')[2];
   updateSkillDerivedForId(section, row_id);
   updateTotalTP(section, 'skill');
@@ -2126,7 +2147,7 @@ const updateSkillDerived = function(section, event) {
 };
 
 const updateAllSkillsDerived = function (section) {
-  getSectionIDs(section, function(ids) {
+  getSectionIDs(section, function (ids) {
     for (let i = 0; i < ids.length; ++i) {
       updateSkillDerivedForId(section, ids[i]);
     }
@@ -2136,21 +2157,21 @@ const updateAllSkillsDerived = function (section) {
 };
 
 on('change:repeating_skill:skilldisciplineinfo' +
-    ' change:repeating_skill:skillexpertise' +
-    ' change:repeating_skill:skillname' + // Fires for new skill.
-    ' remove:repeating_skill' +
-    ' change:_reporder:skill',
-function() { updateSkillDisciplineExpertises('skill'); });
+  ' change:repeating_skill:skillexpertise' +
+  ' change:repeating_skill:skillname' + // Fires for new skill.
+  ' remove:repeating_skill' +
+  ' change:_reporder:skill',
+function () { updateSkillDisciplineExpertises('skill'); });
 
 on('change:repeating_skill:skilldisciplineinfo' +
-    ' change:repeating_skill:skillexpertise' +
-    ' change:repeating_skill:skilldisciplineexpertise' +
-    ' change:repeating_skill:skillattribute' +
-    ' change:repeating_skill:skillbase',
+  ' change:repeating_skill:skillexpertise' +
+  ' change:repeating_skill:skilldisciplineexpertise' +
+  ' change:repeating_skill:skillattribute' +
+  ' change:repeating_skill:skillbase',
 function (event) { updateSkillDerived('skill', event); });
 
-on(  'change:IQ change:DX change:advantage_mage_count'
-    + ' change:advantage_devout_count', 
+on('change:IQ change:DX change:advantage_mage_count'
+  + ' change:advantage_devout_count',
 function () { updateAllSkillsDerived('skill'); });
 
 on('remove:repeating_skill',
@@ -2198,7 +2219,7 @@ const updateArmorValue = function () {
   const reactionPenaltyName = 'reaction_penalty';
   getLargestWeaponDefense((largestWeaponDefense) => {
     getAttrs([armorName, shieldName, defenseBoostName, defendName, reactionPenaltyName],
-      function(values) {
+      function (values) {
         const cur_armor = getValidNumber(values[armorName]);
         const cur_shield = getValidNumber(values[shieldName]);
         const cur_defend = getValidNumber(values[defendName]);
@@ -2228,7 +2249,7 @@ const updateArmorValue = function () {
   });
 };
 on('change:armor_defense change:shield_defense change:defend' +
-  ' change:repeating_weapon:weaponcount' + 
+  ' change:repeating_weapon:weaponcount' +
   ' change:repeating_weapon:weapondefense remove:repeating_weapon' +
   ' change:defense_boost change:reaction_penalty sheet:opened',
 updateArmorValue);
@@ -2237,49 +2258,51 @@ const updateSpeed = function () {
   const DX = 'DX';
   const fast = 'advantage_fast_count';
   const penalty = 'weight_penalty';
-  getAttrs([DX, fast, penalty], function(values) {
+  getAttrs([DX, fast, penalty], function (values) {
     const effective_DX = (Number(values[DX])
-                            + Number(values[fast]));
+      + Number(values[fast]));
     const penalty_n = Number(values[penalty]);
     const DX_reduction = Math.max(0, Math.min(effective_DX,
-      Math.floor(-penalty_n/2)));
-    setAttrs({'speed':
-                Math.max(0, 6 + effective_DX + penalty_n - DX_reduction)});
+      Math.floor(-penalty_n / 2)));
+    setAttrs({
+      'speed':
+        Math.max(0, 6 + effective_DX + penalty_n - DX_reduction)
+    });
   });
 };
 on('change:dx change:advantage_fast_count'
-    + ' change:weight_penalty sheet:opened',
+  + ' change:weight_penalty sheet:opened',
 updateSpeed);
 
 const updateInitiative = function () {
   const IQ = 'IQ';
   const alert = 'advantage_alert_count';
-  getAttrs([IQ, alert], function(values) {
+  getAttrs([IQ, alert], function (values) {
     const effective_IQ = (Number(values[IQ])
-                            + Number(values[alert]));
-    setAttrs({'initiative': effective_IQ});
+      + Number(values[alert]));
+    setAttrs({ 'initiative': effective_IQ });
   });
 };
 on('change:iq change:advantage_alert_count'
-    + ' sheet:opened',
+  + ' sheet:opened',
 updateInitiative);
 
-const updateWeightPenalties = function() {
+const updateWeightPenalties = function () {
   const weight = 'equipment_total_weight';
   const BR = 'BR';
   const packmule = 'advantage_packmule_count';
-  const highlight = function(penalty) {
+  const highlight = function (penalty) {
     return `highlight_weight_penalty_${penalty}`;
   };
-  getAttrs([weight, BR, packmule], function(values) {
+  getAttrs([weight, BR, packmule], function (values) {
     const weight_n = convertToFloat(values[weight]);
     const effective_BR = (Number(values[BR])
-                            + Number(values[packmule]));
+      + Number(values[packmule]));
     let current_level = 0;
     let update = {};
     for (let level = 1; level <= 6; ++level) {
-      const limit = Math.round(((level*level-1)*12/7 + 8.333)
-                                 * 3 * 2**(effective_BR/3));
+      const limit = Math.round(((level * level - 1) * 12 / 7 + 8.333)
+        * 3 * 2 ** (effective_BR / 3));
       if (weight_n >= limit) { current_level = level; }
       update[`penalty_weight_${level}`] = limit;
       update[highlight(level)] = '0';
@@ -2297,45 +2320,45 @@ const updateWeightPenalties = function() {
   });
 };
 on('change:equipment_total_weight' +
-    ' change:br' +
-    ' change:advantage_packmule_count' +
-    ' sheet:opened',
+  ' change:br' +
+  ' change:advantage_packmule_count' +
+  ' sheet:opened',
 updateWeightPenalties);
 
-const updateTotalX = function(x) {
+const updateTotalX = function (x) {
   const armor = `armor_${x}`;
   const shield = `shield_${x}`;
   const weapons = `weapon_total_${x}`;
   const items = `item_total_${x}`;
-  getAttrs([armor, shield, weapons, items], function(values) {
-    let update ={};
+  getAttrs([armor, shield, weapons, items], function (values) {
+    let update = {};
     update[`equipment_total_${x}`] = roundToTwoPlaces(
       convertToFloat(values[armor]) + convertToFloat(values[shield]) +
-              convertToFloat(values[weapons]) + convertToFloat(values[items]));
+      convertToFloat(values[weapons]) + convertToFloat(values[items]));
     setAttrs(update);
   });
 };
 
 on('change:armor_weight change:shield_weight' +
-    ' change:weapon_total_weight change:item_total_weight',
-function() { updateTotalX('weight'); });
+  ' change:weapon_total_weight change:item_total_weight',
+function () { updateTotalX('weight'); });
 on('change:armor_value change:shield_value' +
-    ' change:weapon_total_value change:item_total_value',
-function() { updateTotalX('value'); });
+  ' change:weapon_total_value change:item_total_value',
+function () { updateTotalX('value'); });
 
 // Add up the total weight for repeating_<section>:<section><X>
 // and put it in <section>_total_<X>
-const updateTotalRepeatingX = function(section, x) {
-  getSectionIDs(section, function(ids) {
+const updateTotalRepeatingX = function (section, x) {
+  getSectionIDs(section, function (ids) {
     const x_fields = ids.map(
       id => `repeating_${section}_${id}_${section}${x}`);
     const count_fields = ids.map(
       id => `repeating_${section}_${id}_${section}count`);
-    getAttrs(x_fields.concat(count_fields), function(values) {
+    getAttrs(x_fields.concat(count_fields), function (values) {
       let total = 0;
       for (let i = 0; i < ids.length; ++i) {
         total += (convertToFloat(values[x_fields[i]])
-                    * convertToFloat(values[count_fields[i]]));
+          * convertToFloat(values[count_fields[i]]));
       }
       let update = {};
       update[`${section}_total_${x}`] = total;
@@ -2345,49 +2368,51 @@ const updateTotalRepeatingX = function(section, x) {
 };
 
 on('change:repeating_weapon:weaponweight' +
-    ' change:repeating_weapon:weaponcount' +
-    ' remove:repeating_weapon',
-function() { updateTotalRepeatingX('weapon', 'weight'); });
+  ' change:repeating_weapon:weaponcount' +
+  ' remove:repeating_weapon',
+function () { updateTotalRepeatingX('weapon', 'weight'); });
 on('change:repeating_weapon:weaponvalue' +
-    ' change:repeating_weapon:weaponcount' +
-    ' remove:repeating_weapon',
-function() { updateTotalRepeatingX('weapon', 'value'); });
+  ' change:repeating_weapon:weaponcount' +
+  ' remove:repeating_weapon',
+function () { updateTotalRepeatingX('weapon', 'value'); });
 on('change:repeating_item:itemweight' +
-    ' change:repeating_item:itemcount' +
-    ' remove:repeating_item',
-function() { updateTotalRepeatingX('item', 'weight'); });
+  ' change:repeating_item:itemcount' +
+  ' remove:repeating_item',
+function () { updateTotalRepeatingX('item', 'weight'); });
 on('change:repeating_item:itemvalue' +
-    ' change:repeating_item:itemcount' +
-    ' remove:repeating_item',
-function() { updateTotalRepeatingX('item', 'value'); });
+  ' change:repeating_item:itemcount' +
+  ' remove:repeating_item',
+function () { updateTotalRepeatingX('item', 'value'); });
 
 // -------- Spells ----------
-['arcane','divine', 'innate'].forEach(button => {
-  on(`clicked:${button}`, function() {
-    setAttrs({chosenspelltype: button});
+['arcane', 'divine', 'innate'].forEach(button => {
+  on(`clicked:${button}`, function () {
+    setAttrs({ chosenspelltype: button });
   });
 });
 
 on('change:repeating_arcane:skilldisciplineinfo' +
-    ' change:repeating_arcane:skillexpertise' +
-    ' change:repeating_arcane:skillname' + // Fires for new skill.
-    ' remove:repeating_arcane' +
-    ' change:_reporder:arcane',
-function() { updateSkillDisciplineExpertises('arcane'); });
+  ' change:repeating_arcane:skillexpertise' +
+  ' change:repeating_arcane:skillname' + // Fires for new skill.
+  ' remove:repeating_arcane' +
+  ' change:_reporder:arcane',
+function () { updateSkillDisciplineExpertises('arcane'); });
 
 on('change:repeating_arcane:skilldisciplineinfo' +
-    ' change:repeating_arcane:skillexpertise' +
-    ' change:repeating_arcane:skilldisciplineexpertise' +
-    ' change:repeating_arcane:skillattribute' +
-    ' change:repeating_arcane:skillbase',
+  ' change:repeating_arcane:skillexpertise' +
+  ' change:repeating_arcane:skilldisciplineexpertise' +
+  ' change:repeating_arcane:skillattribute' +
+  ' change:repeating_arcane:skillbase',
 function (event) { updateSkillDerived('arcane', event); });
 
 on('change:IQ change:advantage_mage_count',
   function () { updateAllSkillsDerived('arcane'); });
 
 on('remove:repeating_arcane',
-  function () { updateTotalTP('arcane', 'skill');
-    updateTotalCP('arcane', 'skill');});
+  function () {
+    updateTotalTP('arcane', 'skill');
+    updateTotalCP('arcane', 'skill');
+  });
 
 on('remove:repeating_innate change:repeating_innate:skillCP',
   function () { updateTotalCP('innate', 'skill'); });

--- a/bin/roll20.js
+++ b/bin/roll20.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-const prevEPRoll = function() {
+const prevEPRoll = function () {
   let total = 0;
   let text = '';
   let any_positive = false;
@@ -26,7 +26,7 @@ const prevEPRoll = function() {
         if (roll < 0) {
           any_negative = true;
           roll = '<span style="color:red";>' + roll + '</span>';
-        } else if (roll >  0) {
+        } else if (roll > 0) {
           any_positive = true;
           roll = '<span style="color:blue";>+' + roll + '</span>';
         }
@@ -38,13 +38,15 @@ const prevEPRoll = function() {
       }
     }
   }
-  return {total: total,
-    text: text};
+  return {
+    total: total,
+    text: text
+  };
 };
 
 // Roll a single die, and return its value and text string.
 // If required_sign is present, flip any signed values so they agree with it.
-const RollDie = function(required_sign) {
+const RollDie = function (required_sign) {
   const die = Math.ceil(6 * Math.random());
   let value;
   let text;
@@ -54,14 +56,14 @@ const RollDie = function(required_sign) {
   } else {
     value = die - 3;
     if (required_sign) {
-      if (required_sign != Math.sign(value)) {
+      if (required_sign !== Math.sign(value)) {
         value = -value;
       }
     }
     text = value.toString();
     if (value < 0) {
       text = '<span style="color:red";>' + text + '</span>';
-    } else if (value >  0) {
+    } else if (value > 0) {
       text = '<span style="color:blue";>+' + text + '</span>';
     }
   }
@@ -69,7 +71,7 @@ const RollDie = function(required_sign) {
 };
 
 // Do the EP roll.
-const EPRoll = function() {
+const EPRoll = function () {
   let total = 0;
   let description = '';
   let required_sign = null;
@@ -79,11 +81,11 @@ const EPRoll = function() {
   while (rolls_needed > rolls_done) {
     let [value, text] = RollDie(required_sign);
     rolls_done = rolls_done + 1;
-    if (value == 'two_dice') {
+    if (value === 'two_dice') {
       rolls_needed = rolls_needed + 2;
     }
     // If we are rolling extra dice, the 0s get rerolled.
-    else if (value == 0 && rolls_done > 2) {
+    else if (value === 0 && rolls_done > 2) {
       rolls_needed = rolls_needed + 1;
     } else {
       total = total + value;
@@ -95,15 +97,15 @@ const EPRoll = function() {
     }
     // After we have rolled the first 2 dice,
     // if we got any two_dice rolls, we have to do some special stuff.
-    if (rolls_done == 2 && rolls_needed > 2) {
+    if (rolls_done === 2 && rolls_needed > 2) {
       // If one of the dice was a 0, we have to reroll it.
-      if (total == 0) {
+      if (total === 0) {
         // If one of the dice was a 0, we have to reroll it.
-        if (rolls_needed == 4) {
+        if (rolls_needed === 4) {
           rolls_needed = rolls_needed + 1;
         }
         value = 0;
-        while (value == 0 || value == 'two_dice') {
+        while (value === 0 || value === 'two_dice') {
           [value, text] = RollDie(null);
         }
         total = value;
@@ -112,8 +114,10 @@ const EPRoll = function() {
       required_sign = Math.sign(total);
     }
   }
-  return {total: total,
-    text: description};
+  return {
+    total: total,
+    text: description
+  };
 };
 
 // This script is for rolling success rolls in the Epic Power RPG system.
@@ -122,10 +126,10 @@ const EPRoll = function() {
 // The modifier after !EPRoll can be a sum of terms, like @{X}+@{Y}.
 // If there is additional text after the modifier, it is displayed
 // before the roll.
-on('chat:message', function(event) {
+on('chat:message', function (event) {
   let cmdName = '!EPRoll';
   let msgtxt = event.content;
-  if(event.type == 'api' && msgtxt.indexOf(cmdName) !== -1) {
+  if (event.type === 'api' && msgtxt.indexOf(cmdName) !== -1) {
     let message = msgtxt.slice(cmdName.length + 1).trim();
     let parts = message.split(' ');
     let mod = 0;
@@ -175,23 +179,26 @@ on('chat:message', function(event) {
       // requires a selected token, and there is no selected token
       // when API scripts run.
       const pageid = Campaign().get('playerpageid');
-      const tokens = findObjs({_pageid: pageid,
-        _type: 'graphic'});
+      const tokens = findObjs({
+        _pageid: pageid,
+        _type: 'graphic'
+      });
       const right_tokens = tokens.filter((token) =>
-        token.get('represents') == character_id);
+        token.get('represents') === character_id);
       if (right_tokens.length > 0) {
         token_id = right_tokens[0].id;
-        let turnorder = JSON.parse(Campaign().get('turnorder')||'[]');
+        let turnorder = JSON.parse(Campaign().get('turnorder') || '[]');
         let already_there = false;
         for (let i = 0; i < turnorder.length; i++) {
-          if (turnorder[i].id == token_id) {
+          if (turnorder[i].id === token_id) {
             already_there = true;
             turnorder[i].pr = grand_total;
             break;
           }
         }
         if (!already_there) {
-          turnorder.push({id: token_id,
+          turnorder.push({
+            id: token_id,
             pr: grand_total,
             custom: '',
             _pageid: pageid,
@@ -203,16 +210,16 @@ on('chat:message', function(event) {
   }
 });
 
-on('change:attribute', function(
+on('change:attribute', function (
   attribute,
   // eslint-disable-next-line no-unused-vars
   prev
 ) {
-  if(attribute.get('name') == 'pendingchat') {
+  if (attribute.get('name') === 'pendingchat') {
     let charid = attribute.get('_characterid');
     let message = attribute.get('current');
-    if (message != '') {
-      sendChat('character|'+charid, message);
+    if (message !== '') {
+      sendChat('character|' + charid, message);
       attribute.set('current', '');
     }
   }

--- a/ui/scripts/api/apiScripts.js
+++ b/ui/scripts/api/apiScripts.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-const prevEPRoll = function() {
+const prevEPRoll = function () {
   let total = 0;
   let text = '';
   let any_positive = false;
@@ -26,7 +26,7 @@ const prevEPRoll = function() {
         if (roll < 0) {
           any_negative = true;
           roll = '<span style="color:red";>' + roll + '</span>';
-        } else if (roll >  0) {
+        } else if (roll > 0) {
           any_positive = true;
           roll = '<span style="color:blue";>+' + roll + '</span>';
         }
@@ -38,13 +38,15 @@ const prevEPRoll = function() {
       }
     }
   }
-  return {total: total,
-    text: text};
+  return {
+    total: total,
+    text: text
+  };
 };
 
 // Roll a single die, and return its value and text string.
 // If required_sign is present, flip any signed values so they agree with it.
-const RollDie = function(required_sign) {
+const RollDie = function (required_sign) {
   const die = Math.ceil(6 * Math.random());
   let value;
   let text;
@@ -54,14 +56,14 @@ const RollDie = function(required_sign) {
   } else {
     value = die - 3;
     if (required_sign) {
-      if (required_sign != Math.sign(value)) {
+      if (required_sign !== Math.sign(value)) {
         value = -value;
       }
     }
     text = value.toString();
     if (value < 0) {
       text = '<span style="color:red";>' + text + '</span>';
-    } else if (value >  0) {
+    } else if (value > 0) {
       text = '<span style="color:blue";>+' + text + '</span>';
     }
   }
@@ -69,7 +71,7 @@ const RollDie = function(required_sign) {
 };
 
 // Do the EP roll.
-const EPRoll = function() {
+const EPRoll = function () {
   let total = 0;
   let description = '';
   let required_sign = null;
@@ -79,11 +81,11 @@ const EPRoll = function() {
   while (rolls_needed > rolls_done) {
     let [value, text] = RollDie(required_sign);
     rolls_done = rolls_done + 1;
-    if (value == 'two_dice') {
+    if (value === 'two_dice') {
       rolls_needed = rolls_needed + 2;
     }
     // If we are rolling extra dice, the 0s get rerolled.
-    else if (value == 0 && rolls_done > 2) {
+    else if (value === 0 && rolls_done > 2) {
       rolls_needed = rolls_needed + 1;
     } else {
       total = total + value;
@@ -95,15 +97,15 @@ const EPRoll = function() {
     }
     // After we have rolled the first 2 dice,
     // if we got any two_dice rolls, we have to do some special stuff.
-    if (rolls_done == 2 && rolls_needed > 2) {
+    if (rolls_done === 2 && rolls_needed > 2) {
       // If one of the dice was a 0, we have to reroll it.
-      if (total == 0) {
+      if (total === 0) {
         // If one of the dice was a 0, we have to reroll it.
-        if (rolls_needed == 4) {
+        if (rolls_needed === 4) {
           rolls_needed = rolls_needed + 1;
         }
         value = 0;
-        while (value == 0 || value == 'two_dice') {
+        while (value === 0 || value === 'two_dice') {
           [value, text] = RollDie(null);
         }
         total = value;
@@ -112,8 +114,10 @@ const EPRoll = function() {
       required_sign = Math.sign(total);
     }
   }
-  return {total: total,
-    text: description};
+  return {
+    total: total,
+    text: description
+  };
 };
 
 // This script is for rolling success rolls in the Epic Power RPG system.
@@ -122,10 +126,10 @@ const EPRoll = function() {
 // The modifier after !EPRoll can be a sum of terms, like @{X}+@{Y}.
 // If there is additional text after the modifier, it is displayed
 // before the roll.
-on('chat:message', function(event) {
+on('chat:message', function (event) {
   let cmdName = '!EPRoll';
   let msgtxt = event.content;
-  if(event.type == 'api' && msgtxt.indexOf(cmdName) !== -1) {
+  if (event.type === 'api' && msgtxt.indexOf(cmdName) !== -1) {
     let message = msgtxt.slice(cmdName.length + 1).trim();
     let parts = message.split(' ');
     let mod = 0;
@@ -175,23 +179,26 @@ on('chat:message', function(event) {
       // requires a selected token, and there is no selected token
       // when API scripts run.
       const pageid = Campaign().get('playerpageid');
-      const tokens = findObjs({_pageid: pageid,
-        _type: 'graphic'});
+      const tokens = findObjs({
+        _pageid: pageid,
+        _type: 'graphic'
+      });
       const right_tokens = tokens.filter((token) =>
-        token.get('represents') == character_id);
+        token.get('represents') === character_id);
       if (right_tokens.length > 0) {
         token_id = right_tokens[0].id;
-        let turnorder = JSON.parse(Campaign().get('turnorder')||'[]');
+        let turnorder = JSON.parse(Campaign().get('turnorder') || '[]');
         let already_there = false;
         for (let i = 0; i < turnorder.length; i++) {
-          if (turnorder[i].id == token_id) {
+          if (turnorder[i].id === token_id) {
             already_there = true;
             turnorder[i].pr = grand_total;
             break;
           }
         }
         if (!already_there) {
-          turnorder.push({id: token_id,
+          turnorder.push({
+            id: token_id,
             pr: grand_total,
             custom: '',
             _pageid: pageid,
@@ -203,16 +210,16 @@ on('chat:message', function(event) {
   }
 });
 
-on('change:attribute', function(
+on('change:attribute', function (
   attribute,
   // eslint-disable-next-line no-unused-vars
   prev
 ) {
-  if(attribute.get('name') == 'pendingchat') {
+  if (attribute.get('name') === 'pendingchat') {
     let charid = attribute.get('_characterid');
     let message = attribute.get('current');
-    if (message != '') {
-      sendChat('character|'+charid, message);
+    if (message !== '') {
+      sendChat('character|' + charid, message);
       attribute.set('current', '');
     }
   }

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1,10 +1,10 @@
 'use strict';
 // ----- Utilities -----
-const removeNonNumeric = function(s) {
+const removeNonNumeric = function (s) {
   return String(s).trim().replace(/[^\d.-]/g, '');
 };
 
-const convertToFloat = function(s) {
+const convertToFloat = function (s) {
   let str = removeNonNumeric(s);
   if (!str) {
     return 0;
@@ -18,32 +18,32 @@ const convertToFloat = function(s) {
   }
 };
 
-const roundToTwoPlaces = function(s) {
-  return Math.floor(s*100)/100;
+const roundToTwoPlaces = function (s) {
+  return Math.floor(s * 100) / 100;
 };
 
-const sumValues = function(value_map) {
+const sumValues = function (value_map) {
   return Object.values(value_map).reduce(
     (accum, b) => accum + convertToFloat(b), 0);
 };
 
-const sumSingleValues = function(value_map) {
+const sumSingleValues = function (value_map) {
   return Object.values(value_map).reduce(
     (accum, b) => accum + (convertToFloat(b) === 1 ? 1 : 0),
     0);
 };
 
-const isEmptyValue = function(value) {
+const isEmptyValue = function (value) {
   return value === undefined || value.trim() === '';
 };
 
 // Add up the total cost for repeating_<section>:<name>TP
 // and put it in <section>_total_TP
-const updateTotalTP = function(section, name) {
+const updateTotalTP = function (section, name) {
   if (name === undefined) { name = section; }
-  getSectionIDs(section, function(ids) {
+  getSectionIDs(section, function (ids) {
     let TP_fields = ids.map(id => `repeating_${section}_${id}_${name}TP`);
-    getAttrs(TP_fields, function(tps) {
+    getAttrs(TP_fields, function (tps) {
       let update = {};
       update[section + '_total_TP'] = sumValues(tps);
       setAttrs(update);
@@ -53,18 +53,18 @@ const updateTotalTP = function(section, name) {
 
 // We record the number of CP costs of 1. This adds them all up,
 // and subtracts as many of them from the total as breadth allows.
-const updateDistributedCP = function() {
+const updateDistributedCP = function () {
   const feat = 'feat_total_single_CP';
   const skill = 'skill_total_single_CP';
   const arcane = 'arcane_total_single_CP';
   const innate = 'innate_total_single_CP';
   const tp = 'TP';
-  getAttrs([feat, skill, arcane, innate, tp], 
-    function(singles) {
+  getAttrs([feat, skill, arcane, innate, tp],
+    function (singles) {
       const total = (Number(singles[feat])
-              + Number(singles[skill])
-              + Number(singles[arcane])
-              + Number(singles[innate]));
+        + Number(singles[skill])
+        + Number(singles[arcane])
+        + Number(singles[innate]));
       // log("inputs: " + "'" + singles[advantage] 
       //                + "' '" + singles[feat]
       //                + "' '" + singles[skill]
@@ -72,24 +72,24 @@ const updateDistributedCP = function() {
       //                + "' '" + singles[innate] + "'");
       // log("Distributed: " + Math.min(total, Math.min(singles[tp], 6)
       //     + "  " + total);
-      setAttrs({'distributed_CP': Math.min(total, Math.min(singles[tp], 6))});
+      setAttrs({ 'distributed_CP': Math.min(total, Math.min(singles[tp], 6)) });
     });
 };
 
 on('change:tp' +
-      ' change:feat_total_single_CP' +
-      ' change:skill_total_single_CP' +
-      ' change:arcane_total_single_CP' +
-      ' change:innate_total_single_CP',
-updateDistributedCP);  
+  ' change:feat_total_single_CP' +
+  ' change:skill_total_single_CP' +
+  ' change:arcane_total_single_CP' +
+  ' change:innate_total_single_CP',
+updateDistributedCP);
 
 // Add up the total cost for repeating_<section>:<name>CP
 // and put it in <section>_total_CP
-const updateTotalCP = function(section, name) {
+const updateTotalCP = function (section, name) {
   if (name === undefined) { name = section; }
-  getSectionIDs(section, function(ids) {
+  getSectionIDs(section, function (ids) {
     let CP_fields = ids.map(id => `repeating_${section}_${id}_${name}CP`);
-    getAttrs(CP_fields, function(cps) {
+    getAttrs(CP_fields, function (cps) {
       let update = {};
       update[section + '_total_CP'] = sumValues(cps);
       update[section + '_total_single_CP'] = sumSingleValues(cps);
@@ -114,11 +114,11 @@ const getSectionIDsOrdered = function (sectionName, callback) {
 
 // ----- Top action and roll -----
 
-const toggleSavePending = function() {
+const toggleSavePending = function () {
   getAttrs(['save_pending'],
-    function(values) {
+    function (values) {
       let new_value = Number(values['save_pending']) ? 0 : 1;
-      setAttrs({'save_pending': new_value});
+      setAttrs({ 'save_pending': new_value });
     });
 };
 on('clicked:saveroll', toggleSavePending);
@@ -129,11 +129,13 @@ const roll_keys = ['action_description', 'action_feats',
   'roll_mod1', 'roll_mod2', 'roll_mod3',
   'roll_advance_boost'];
 
-const saveRollState = function(key, roll_chosen) {
+const saveRollState = function (key, roll_chosen) {
   getAttrs(roll_keys,
-    function(values) {
-      let update = {'save_pending': 0,
-        'roll_chosen': roll_chosen};
+    function (values) {
+      let update = {
+        'save_pending': 0,
+        'roll_chosen': roll_chosen
+      };
       // We write the values in a fixed order, so we can do equality
       // checks.
       update[key] = JSON.stringify(values, roll_keys);
@@ -141,10 +143,10 @@ const saveRollState = function(key, roll_chosen) {
     });
 };
 
-const loadRollState = function(key, roll_chosen) {
+const loadRollState = function (key, roll_chosen) {
   getAttrs([key],
-    function(values) {
-      if (values[key] != '') {
+    function (values) {
+      if (values[key] !== '') {
         let change = JSON.parse(values[key]);
         change['roll_chosen'] = roll_chosen;
         setAttrs(change);
@@ -155,16 +157,16 @@ const loadRollState = function(key, roll_chosen) {
     });
 };
 
-const checkRollChosen = function() {
-  getAttrs(['roll_chosen'], function(values) {
+const checkRollChosen = function () {
+  getAttrs(['roll_chosen'], function (values) {
     let roll_chosen = Number(values['roll_chosen']);
     if (roll_chosen) {
       let saved_roll = 'saved_roll_' + roll_chosen;
-      getAttrs(roll_keys.concat([saved_roll]), function(values) {
+      getAttrs(roll_keys.concat([saved_roll]), function (values) {
         let saved = values[saved_roll];
         let current = JSON.stringify(values, roll_keys);
-        if (saved != current) {
-          setAttrs({'roll_chosen': ''});
+        if (saved !== current) {
+          setAttrs({ 'roll_chosen': '' });
         }
       });
     }
@@ -172,9 +174,9 @@ const checkRollChosen = function() {
 };
 on(roll_keys.map(name => 'change:' + name).join(' '), checkRollChosen);
 
-const doChooseRoll = function(number) {
+const doChooseRoll = function (number) {
   let saved_roll = 'saved_roll_' + number;
-  getAttrs(['save_pending'], function(values) {
+  getAttrs(['save_pending'], function (values) {
     if (Number(values['save_pending'])) {
       saveRollState(saved_roll, number);
     } else {
@@ -183,45 +185,53 @@ const doChooseRoll = function(number) {
   });
 };
 const roll_choices = ['1', '2', '3', '4', '5', '6'];
-roll_choices.forEach(function(value) {
-  on(`clicked:choose_roll_${value}`, function() { doChooseRoll(value); });
+roll_choices.forEach(function (value) {
+  on(`clicked:choose_roll_${value}`, function () { doChooseRoll(value); });
 });
 
-const topActionDeltas = function(values) {
-  let action_feats =  Number(values['action_feats']);
+const topActionDeltas = function (values) {
+  let action_feats = Number(values['action_feats']);
   let feats_EP = action_feats;
   let action_EP = Number(values['action_EP']);
   let action_SP = Number(values['action_SP']);
-  return {'EPS': (action_feats != 0 ? [-feats_EP] : []).concat(
-    (action_EP != 0 ? [-action_EP] : [])),
-  'SPS': action_SP != 0 ? [-action_SP] : []};
+  return {
+    'EPS': (action_feats !== 0 ? [-feats_EP] : []).concat(
+      (action_EP !== 0 ? [-action_EP] : [])),
+    'SPS': action_SP !== 0 ? [-action_SP] : []
+  };
 };
 
-const topRollDeltas = function(values) {
-  let advance_boost =  Number(values['roll_advance_boost']);
+const topRollDeltas = function (values) {
+  let advance_boost = Number(values['roll_advance_boost']);
   let boost_EP = advance_boost;
-  return {'EPS': advance_boost != 0 ? [-boost_EP] : [],
-    'SPS': []};
+  return {
+    'EPS': advance_boost !== 0 ? [-boost_EP] : [],
+    'SPS': []
+  };
 };
 
-const addDeltas = function(deltas1, deltas2) {
-  return {'EPS': deltas1['EPS'].concat(deltas2['EPS']),
-    'SPS': deltas1['SPS'].concat(deltas2['SPS'])};
+const addDeltas = function (deltas1, deltas2) {
+  return {
+    'EPS': deltas1['EPS'].concat(deltas2['EPS']),
+    'SPS': deltas1['SPS'].concat(deltas2['SPS'])
+  };
 };
 
-const multiplyDeltas = function(deltas, multiplier) {
-  return {'EPS': deltas['EPS'].map(x => x * multiplier),
-    'SPS': deltas['SPS'].map(x => x * multiplier)};
+const multiplyDeltas = function (deltas, multiplier) {
+  return {
+    'EPS': deltas['EPS'].map(x => x * multiplier),
+    'SPS': deltas['SPS'].map(x => x * multiplier)
+  };
 };
 
-const modifiersToTotal = function(modifiers) {
+const modifiersToTotal = function (modifiers) {
   return modifiers.reduce((accum, modifier) => accum + modifier,
     0);
 };
 
-const modifiersToString = function(modifiers) {
-  return modifiers.reduce(function(accum, modifier) {
-    if (modifier == 0) {
+const modifiersToString = function (modifiers) {
+  return modifiers.reduce(function (accum, modifier) {
+    if (modifier === 0) {
       return accum;
     } else if (modifier > 0) {
       return accum + '+' + String(modifier);
@@ -232,31 +242,33 @@ const modifiersToString = function(modifiers) {
   '');
 };
 
-const isLegalUpdate = function(current, deltas) {
-  return (   (-modifiersToTotal(deltas['EPS']) <=  Number(current['EP_t']))
-          && (-modifiersToTotal(deltas['SPS']) <=  Number(current['SP'])));
+const isLegalUpdate = function (current, deltas) {
+  return ((-modifiersToTotal(deltas['EPS']) <= Number(current['EP_t']))
+    && (-modifiersToTotal(deltas['SPS']) <= Number(current['SP'])));
 };
 
-const makeUpdate = function(current, deltas) {
+const makeUpdate = function (current, deltas) {
   let EP_delta = modifiersToTotal(deltas['EPS']);
   const current_EP_t = Number(current['EP_t']);
   const EP_t_max = Number(current['EP_t_max']);
   const new_EP_t = Math.max(0, Math.min(EP_t_max * 2, current_EP_t + EP_delta));
   // log("EP_delta " + EP_delta + "  current_EP_t " + current_EP_t);
   // log("EP_t_max " + EP_t_max + "  new_EP_t" + new_EP_t);
-  return {'EP_t': new_EP_t,
-    'SP': Number(current['SP']) + modifiersToTotal(deltas['SPS'])};
+  return {
+    'EP_t': new_EP_t,
+    'SP': Number(current['SP']) + modifiersToTotal(deltas['SPS'])
+  };
 };
 
-const deltasDescription = function(deltas) {
+const deltasDescription = function (deltas) {
   let description = '';
   if (deltas['EPS'].length) {
     description = (description + ' ('
-                    + modifiersToString(deltas['EPS']) + ' EP)');
+      + modifiersToString(deltas['EPS']) + ' EP)');
   }
   if (deltas['SPS'].length) {
-    description = (description + ' (' 
-                    + modifiersToString(deltas['SPS']) + ' SP)');
+    description = (description + ' ('
+      + modifiersToString(deltas['SPS']) + ' SP)');
   }
   return description;
 };
@@ -264,12 +276,12 @@ const deltasDescription = function(deltas) {
 const doTopAction = function () {
   getAttrs(['EP_t', 'EP_t_max', 'SP',
     'action_description', 'action_feats',
-    'action_EP', 'action_SP'], 
-  function(values) {
+    'action_EP', 'action_SP'],
+  function (values) {
     let deltas = topActionDeltas(values);
     let update = makeUpdate(values, deltas);
-    update['pendingchat'] = (  values['action_description']
-                                + deltasDescription(deltas));
+    update['pendingchat'] = (values['action_description']
+        + deltasDescription(deltas));
     setAttrs(update);
   });
 };
@@ -278,11 +290,11 @@ on('clicked:topaction', doTopAction);
 const undoTopAction = function () {
   getAttrs(['EP_t', 'EP_t_max', 'SP',
     'action_feats', 'action_EP', 'action_SP'],
-  function(values) {
+  function (values) {
     let deltas = multiplyDeltas(topActionDeltas(values), -1);
     let update = makeUpdate(values, deltas);
     let restored = deltasDescription(deltas);
-    if (restored != '') {
+    if (restored !== '') {
       update['pendingchat'] = 'Undo restoring' + restored;
     }
     setAttrs(update);
@@ -290,15 +302,15 @@ const undoTopAction = function () {
 };
 on('clicked:undotopaction', undoTopAction);
 
-const topRollCommand = function(values) {
-  let ability =  Number(values['roll_ability']);
+const topRollCommand = function (values) {
+  let ability = Number(values['roll_ability']);
   let modifiers = [Number(values['roll_mod1']),
     Number(values['roll_mod2']),
     Number(values['roll_mod3']),
     Number(values['roll_advance_boost'])];
   let base = ability + modifiersToTotal(modifiers);
-  let description = (  values['roll_skill'] + ' '
-                      + String(ability) + modifiersToString(modifiers));
+  let description = (values['roll_skill'] + ' '
+    + String(ability) + modifiersToString(modifiers));
   return '!EPRoll ' + String(base) + ' Tries ' + description;
 };
 
@@ -308,13 +320,13 @@ const doTopRoll = function () {
     'action_EP', 'action_SP',
     'roll_skill', 'roll_ability',
     'roll_mod1', 'roll_mod2', 'roll_mod3', 'roll_advance_boost'],
-  function(values) {
+  function (values) {
     let deltas = addDeltas(topActionDeltas(values),
       topRollDeltas(values));
     let update = makeUpdate(values, deltas);
-    let description = ( values['action_description']
-                          + deltasDescription(deltas));
-    if (description != '') {
+    let description = (values['action_description']
+        + deltasDescription(deltas));
+    if (description !== '') {
       description = description + '\n';
     }
     update['pendingchat'] = description + topRollCommand(values);
@@ -327,13 +339,13 @@ const undoTopRoll = function () {
   getAttrs(['EP_t', 'EP_t_max', 'SP',
     'action_feats', 'action_EP', 'action_SP',
     'roll_advance_boost'],
-  function(values) {
+  function (values) {
     let deltas = multiplyDeltas(addDeltas(topActionDeltas(values),
       topRollDeltas(values)),
     -1);
     let update = makeUpdate(values, deltas);
     let restored = deltasDescription(deltas);
-    if (restored != '') {
+    if (restored !== '') {
       update['pendingchat'] = 'Undo restoring' + restored;
     }
     setAttrs(update);
@@ -397,77 +409,82 @@ const updateTopActEnables = function () {
   log('Updating top action enables');
   getAttrs(['EP_t', 'SP',
     'action_feats', 'action_EP', 'action_SP', 'roll_advance_boost'],
-  function(values) {
+  function (values) {
     let top_action_deltas = topActionDeltas(values);
     let top_roll_deltas = addDeltas(topActionDeltas(values),
       topRollDeltas(values));
     log(values);
     log(top_action_deltas);
-    let update = {'disable_do':
-                      isLegalUpdate(values, top_action_deltas) ? '0' : '1',
-    'disable_do_and_roll':
-                      isLegalUpdate(values, top_roll_deltas) ? '0' : '1'};
+    let update = {
+      'disable_do':
+          isLegalUpdate(values, top_action_deltas) ? '0' : '1',
+      'disable_do_and_roll':
+          isLegalUpdate(values, top_roll_deltas) ? '0' : '1'
+    };
     log(update);
     setAttrs(update);
   });
 };
 
 on('change:ep_t' +
-    ' change:sp' +
-    ' change:action_feats' +
-    ' change:action_ep' +
-    ' change:action_sp' +
-    ' change:roll_advance_boost',
+  ' change:sp' +
+  ' change:action_feats' +
+  ' change:action_ep' +
+  ' change:action_sp' +
+  ' change:roll_advance_boost',
 updateTopActEnables);
 
 // ----- EP_t, and SP ----
-const updateEP = function() {
+const updateEP = function () {
   const power = 'power';
   const EP_t_max = 'EP_t_max';
   const SP_max = 'SP_max';
-  getAttrs([power, EP_t_max, SP_max], function(values) {
+  getAttrs([power, EP_t_max, SP_max], function (values) {
     let power_v = Number(values[power]);
     const EP_t_max_v = Number(values[EP_t_max]);
     const SP_max_v = Number(values[SP_max]);
     const power_points = (power_v < 6 ?
       power_v :
-      Math.floor(5*(Math.sqrt(power_v - 1) - 1)));
+      Math.floor(5 * (Math.sqrt(power_v - 1) - 1)));
     const new_SP_max = Math.floor((power_points - 3 * EP_t_max_v) / 2);
     // We get called from spurrios changes to SP_max,
     // So only reset all the values if something actually changed.
     log('EP_t: ' + EP_t_max_v + '  SP: ' + SP_max_v
-          + '  new SP: ' + new_SP_max);
-    if (new_SP_max != SP_max_v) {
-      setAttrs({'EP_t': EP_t_max_v,
+      + '  new SP: ' + new_SP_max);
+    if (new_SP_max !== SP_max_v) {
+      setAttrs({
+        'EP_t': EP_t_max_v,
         'SP_max': new_SP_max,
-        'SP': new_SP_max});
+        'SP': new_SP_max
+      });
     }
   });
 };
 on('change:power change:ep_t_max', updateEP);
 
-const fixPower = function() {
+const fixPower = function () {
   const power = 'power';
   const EP_max = 'EP_max';
   const SP_max = 'SP_max';
-  getAttrs([power, EP_max, SP_max], function(values) {
+  getAttrs([power, EP_max, SP_max], function (values) {
     let power_v = Number(values[power]);
     const EP_max_v = Number(values[EP_max]);
     const SP_max_v = Number(values[SP_max]);
     // Set power to EP if we have an old sheet, where it wasn't set yet.
-    if (power_v == 0 && SP_max_v == 0 && EP_max_v > 0) {
+    if (power_v === 0 && SP_max_v === 0 && EP_max_v > 0) {
       power_v = EP_max_v;
     }
-    setAttrs({'power': power_v}, null, updateEP);
+    setAttrs({ 'power': power_v }, null, updateEP);
   });
 };
 on('sheet:opened', fixPower);
 
 // ----- Tab navigation -----
 ['overview', 'basic', 'equipment', 'skills', 'spells', 'notes'].forEach(
-  button => { on(`clicked:${button}`, function() {
-    setAttrs({chosentab: button});
-  });
+  button => {
+    on(`clicked:${button}`, function () {
+      setAttrs({ chosentab: button });
+    });
   });
 
 // ----- Popovers -----
@@ -511,21 +528,21 @@ function setupSpellNotes(spellDomain) {
 const updateTP = function () {
   const CP = 'CP';
   // const TP = 'TP';
-  getAttrs([CP], function(values) {
-    const TP_v = Math.floor(Number(values[CP])/10);
-    setAttrs({'TP': TP_v});
+  getAttrs([CP], function (values) {
+    const TP_v = Math.floor(Number(values[CP]) / 10);
+    setAttrs({ 'TP': TP_v });
   });
 };
 on('change:cp sheet:opened', updateTP);
 
 // ----- Attribute costs -----
-const updateAttributeCost = function() {
-  getAttrs(['IQ', 'DX', 'BR'], function(attributes) {
+const updateAttributeCost = function () {
+  getAttrs(['IQ', 'DX', 'BR'], function (attributes) {
     const IQ = Number(attributes.IQ);
     const DX = Number(attributes.DX);
     const BR = Number(attributes.BR);
     const total = IQ + DX + BR;
-    const total_squares = IQ**2 + DX**2 + BR**2;
+    const total_squares = IQ ** 2 + DX ** 2 + BR ** 2;
     let cost = '??';
     if (total === 3) {
       if (total_squares === 3) {
@@ -536,8 +553,10 @@ const updateAttributeCost = function() {
         cost = 10;
       }
     }
-    setAttrs({displayed_attribute_CP: String(cost),
-      attribute_CP: cost === '??' ? 0 : cost});
+    setAttrs({
+      displayed_attribute_CP: String(cost),
+      attribute_CP: cost === '??' ? 0 : cost
+    });
   });
 };
 on('change:iq change:dx change:br', updateAttributeCost);
@@ -564,7 +583,7 @@ const advantageCosts = {
 
 // Advantages used to be stored as _plus or _minus, rather than as _count.
 // Go through all of those, transfer them to _count, and eliminate them.
-const migrateAdvantages = function() {
+const migrateAdvantages = function () {
   const fixed_advantage_prefixes = Object.keys(advantageCosts).map(
     advantage => 'advantage_' + advantage + '_');
   const fixed_advantage_plus_fields = fixed_advantage_prefixes.map(
@@ -572,13 +591,13 @@ const migrateAdvantages = function() {
   const fixed_advantage_minus_fields = fixed_advantage_prefixes.map(
     prefix => prefix + 'minus');
   getAttrs(fixed_advantage_plus_fields.concat(fixed_advantage_minus_fields),
-    function(attributes) {
+    function (attributes) {
       const update = {};
       for (const advantage of Object.keys(advantageCosts)) {
         const prefix = 'advantage_' + advantage + '_';
         for (const polarity of ['plus', 'minus']) {
-          if (Number(attributes[prefix + polarity]) == 1) {
-            update[prefix + 'count'] = polarity == 'plus' ? '1' : '-1';
+          if (Number(attributes[prefix + polarity]) === 1) {
+            update[prefix + 'count'] = polarity === 'plus' ? '1' : '-1';
             update[prefix + polarity] = '0';
           }
         }
@@ -598,7 +617,7 @@ on('sheet:opened', migrateAdvantages);
 // how the cost of that advantage was computed.
 // Return the total of all the costs.
 // The order of the elements of the array may be changed by the function.
-const calculateAdvantageCosts = function(advantages) {
+const calculateAdvantageCosts = function (advantages) {
   log('Calculating');
   // Sort them from most expensive to least.
   advantages.sort(function (a, b) { return b.base_cost - a.base_cost; });
@@ -611,13 +630,13 @@ const calculateAdvantageCosts = function(advantages) {
       total_cost += -Math.floor(base_cost / 2);
       advantage.cost_description = '-' + String(base_cost) + '/2';
     } else if (count > 0) {
-      if (base_cost <= 0 ) {
+      if (base_cost <= 0) {
         total_cost += base_cost;
         advantage.cost_description = String(base_cost);
       } else {
-        const multiplier = (seen+1 + seen+count) * count / 2;
+        const multiplier = (seen + 1 + seen + count) * count / 2;
         total_cost += base_cost * multiplier;
-        if (multiplier == 1) {
+        if (multiplier === 1) {
           advantage.cost_description = String(base_cost);
         } else {
           advantage.cost_description = (
@@ -639,13 +658,13 @@ const updateAdvantagesCosts = function () {
     advantage => 'advantage_' + advantage + '_');
   const fixed_advantage_count_fields = fixed_advantage_prefixes.map(
     prefix => prefix + 'count');
-  getSectionIDs('extraadvantage', function(extra_ids) {
-    const extra_advantage_cost_fields =  extra_ids.map(
+  getSectionIDs('extraadvantage', function (extra_ids) {
+    const extra_advantage_cost_fields = extra_ids.map(
       id => 'repeating_extraadvantage_' + id + '_extraadvantageCP');
     getAttrs(fixed_advantage_count_fields.concat(extra_advantage_cost_fields),
-      function(attributes) {
+      function (attributes) {
         const fixed_advantages = Object.keys(advantageCosts).map(
-          function(advantage) {
+          function (advantage) {
             const prefix = 'advantage_' + advantage + '_';
             return {
               description_key: prefix + 'CPdescription',
@@ -654,7 +673,7 @@ const updateAdvantagesCosts = function () {
             };
           });
         const extra_advantages = extra_ids.map(
-          function(extra_id) {
+          function (extra_id) {
             const prefix = 'repeating_extraadvantage_' + extra_id + '_';
             return {
               description_key: prefix + 'extraadvantageCPdescription',
@@ -664,7 +683,7 @@ const updateAdvantagesCosts = function () {
           });
         const advantages = fixed_advantages.concat(extra_advantages);
         const total_cost = calculateAdvantageCosts(advantages);
-        const update = {advantage_total_CP: total_cost};
+        const update = { advantage_total_CP: total_cost };
         for (const advantage of advantages) {
           update[advantage.description_key] = advantage.cost_description;
         }
@@ -678,62 +697,64 @@ on(Object.keys(advantageCosts).map(
 ).join(' '),
 updateAdvantagesCosts);
 
-on((  'change:repeating_extraadvantage:extraadvantageCP'
-    + ' remove:repeating_extraadvantage'),
+on(('change:repeating_extraadvantage:extraadvantageCP'
+  + ' remove:repeating_extraadvantage'),
 updateAdvantagesCosts);
 
 const updateHPMax = function () {
   const BR = 'BR';
   const healthy = 'advantage_healthy_count';
-  getAttrs([BR, healthy], function(values) {
+  getAttrs([BR, healthy], function (values) {
     const effective_BR = (Number(values[BR])
-                      + Number(values[healthy]));
+      + Number(values[healthy]));
     const max_hp = (effective_BR <= -3 ?
       8 + effective_BR :
-      12 + effective_BR*(effective_BR+7)/2);
-    setAttrs({'HP_max': max_hp});
+      12 + effective_BR * (effective_BR + 7) / 2);
+    setAttrs({ 'HP_max': max_hp });
   });
 };
 on('change:br change:advantage_healthy_count' +
-    ' sheet:opened',
+  ' sheet:opened',
 updateHPMax);
 
-const reset_EP_t = function() {
+const reset_EP_t = function () {
   const EP_t = 'EP_t';
   const EP_t_max = 'EP_t_max';
-  getAttrs([EP_t, EP_t_max], function(values) {
+  getAttrs([EP_t, EP_t_max], function (values) {
     const EP_t_max_v = Number(values[EP_t_max]);
-    setAttrs({EP_t: EP_t_max_v + Math.min(EP_t_max_v, Number(values[EP_t]))});
+    setAttrs({ EP_t: EP_t_max_v + Math.min(EP_t_max_v, Number(values[EP_t])) });
   });
 };
 on('clicked:reset_ep_t', reset_EP_t);
 
-const convertSP = function() {
+const convertSP = function () {
   const EP_t = 'EP_t';
   const SP = 'SP';
-  getAttrs([EP_t, SP], function(attributes) {
+  getAttrs([EP_t, SP], function (attributes) {
     let EP_t_v = Number(attributes[EP_t]);
     let SP_v = Number(attributes[SP]);
     if (SP_v > 0) {
-      setAttrs({'EP_t': EP_t_v + 2,
-        'SP': SP_v - 1});
+      setAttrs({
+        'EP_t': EP_t_v + 2,
+        'SP': SP_v - 1
+      });
     }
   });
 };
 on('clicked:convert_sp', convertSP);
 
-const reset_SP = function() {
+const reset_SP = function () {
   const SP_max = 'SP_max';
-  getAttrs([SP_max], function(values) {
-    setAttrs({'SP': values[SP_max]});
+  getAttrs([SP_max], function (values) {
+    setAttrs({ 'SP': values[SP_max] });
   });
 };
 on('clicked:reset_sp', reset_SP);
 
-const reset_HP = function() {
+const reset_HP = function () {
   const HP_max = 'HP_max';
-  getAttrs([HP_max], function(values) {
-    setAttrs({'HP': values[HP_max]});
+  getAttrs([HP_max], function (values) {
+    setAttrs({ 'HP': values[HP_max] });
   });
 };
 on('clicked:reset_hp', reset_HP);
@@ -742,11 +763,11 @@ on('clicked:reset_hp', reset_HP);
 // ----- Epic Feats -----
 
 // Set E for extraordinary
-on('change:repeating_feat:featextraordinary', function() {
+on('change:repeating_feat:featextraordinary', function () {
   getAttrs(['repeating_feat_featextraordinary'], function (values) {
     const letter = (
       values.repeating_feat_featextraordinary === '1' ? 'E' : ' ');
-    setAttrs({'repeating_feat_featextraordinaryletter': letter});
+    setAttrs({ 'repeating_feat_featextraordinaryletter': letter });
   });
 });
 
@@ -756,18 +777,18 @@ on('change:repeating_feat:featcp remove:repeating_feat',
 // Set default CP cost
 // There is no event for a row being added, so new rows start out with
 // empty cost. Then we set it to the usual 4 when a feat name is entered.
-on('change:repeating_feat:featname', function(event) {
+on('change:repeating_feat:featname', function (event) {
   let prev_name = event.previousValue;
   const new_name = event.newValue;
   // When a new row is filled in for the first time, previousValue
   // comes back as the new value.
-  if (prev_name == new_name) { prev_name = undefined; }
+  if (prev_name === new_name) { prev_name = undefined; }
   if (isEmptyValue(prev_name) !== isEmptyValue(new_name)) {
     let field_name_parts = event.sourceAttribute.split('_');
     field_name_parts.pop();
     field_name_parts.push('featCP');
     const CP_field = field_name_parts.join('_');
-    getAttrs([field_name_parts.join('_')], function(values) {
+    getAttrs([field_name_parts.join('_')], function (values) {
       const prev_CP_cost = values[CP_field];
       if (isEmptyValue(prev_CP_cost) === isEmptyValue(prev_name)) {
         let default_value = {};
@@ -787,7 +808,7 @@ function isValueDefined(value) {
 const updateCopiedAbilities = function () {
   const DX = 'DX';
   const weight_penalty = 'weight_penalty';
-  getSectionIDsOrdered('skill', function(ids) {
+  getSectionIDsOrdered('skill', function (ids) {
     const disciplineinfos = ids.map(
       id => `repeating_skill_${id}_skilldisciplineinfo`);
     const expertises = ids.map(
@@ -798,7 +819,7 @@ const updateCopiedAbilities = function () {
       id => `repeating_skill_${id}_skillname`);
     getAttrs(disciplineinfos.concat(expertises)
       .concat(abilities).concat(names)
-      .concat([DX, weight_penalty]), function(values) {
+      .concat([DX, weight_penalty]), function (values) {
       const DX_n = Number(values[DX]);
       const weight_penalty_n = Number(values[weight_penalty]);
       // Make a map from skill names to their index.
@@ -815,7 +836,7 @@ const updateCopiedAbilities = function () {
           const discipline_index = skill_map[discipline];
           const expertise_v = values[expertises[discipline_index]];
           if (values[disciplineinfos[discipline_index]] === 'D'
-                && expertise_v !== '--') {
+              && expertise_v !== '--') {
             min_expertise = -2 + Number(expertise_v);
           }
         }
@@ -830,7 +851,7 @@ const updateCopiedAbilities = function () {
           skill === 'spell touch' ?
             min_expertises['attack'] + 4 :
             Math.max(min_expertises['defense'],
-              min_expertises['defend'])- 3);
+              min_expertises['defend']) - 3);
         let skill_index = skill_map[skill];
         if (isValueDefined(skill_index) && values[disciplineinfos[skill_index]] === 'D') {
           skill_index = null;
@@ -857,11 +878,11 @@ const updateCopiedAbilities = function () {
   });
 };
 on('change:repeating_skill:skilldisciplineinfo' +
-    ' change:repeating_skill:skillexpertise' +
-    ' change:repeating_skill:skillability' +
-    ' change:repeating_skill:skillname' +
-    ' change:DX change:weight_penalty remove:repeating_skill' +
-    ' sheet:opened',
+  ' change:repeating_skill:skillexpertise' +
+  ' change:repeating_skill:skillability' +
+  ' change:repeating_skill:skillname' +
+  ' change:DX change:weight_penalty remove:repeating_skill' +
+  ' sheet:opened',
 updateCopiedAbilities);
 
 // skilldisciplineexpertise holds the expertise of the discipline that
@@ -869,7 +890,7 @@ updateCopiedAbilities);
 // note which are disciplines, and set the discipline expertise of
 // all skills to that of the most recent discipline we encountered.
 const updateSkillDisciplineExpertises = function (section) {
-  getSectionIDsOrdered(section, function(ids) {
+  getSectionIDsOrdered(section, function (ids) {
     const disciplineinfos = ids.map(
       id => `repeating_${section}_${id}_skilldisciplineinfo`);
     const isdisciplines = ids.map(
@@ -880,18 +901,18 @@ const updateSkillDisciplineExpertises = function (section) {
       id => `repeating_${section}_${id}_skilldisciplineexpertise`);
     getAttrs(disciplineinfos.concat(isdisciplines).concat(expertises)
       .concat(disciplineexpertises),
-    function(attributes) {
+    function (attributes) {
       let discipline_expertise = 0;
       let update = {};
       for (let i = 0; i < ids.length; ++i) {
         if (attributes[disciplineinfos[i]] === 'D') {
           discipline_expertise = attributes[expertises[i]];
-          if (attributes[isdisciplines[i]] != 1) {
-            update[isdisciplines[i]] = 1;
+          if (attributes[isdisciplines[i]] !== '1') {
+            update[isdisciplines[i]] = '1';
           }
         } else {
-          if (attributes[isdisciplines[i]] != 0) {
-            update[isdisciplines[i]] = 0;
+          if (attributes[isdisciplines[i]] !== '0') {
+            update[isdisciplines[i]] = '0';
           }
           let this_discipline_expertise = 0;
           if (attributes[disciplineinfos[i]] === '⇡') {
@@ -902,14 +923,14 @@ const updateSkillDisciplineExpertises = function (section) {
           }
         }
       }
-      if (! _.isEmpty(update)) {
+      if (!_.isEmpty(update)) {
         setAttrs(update);
       }
     });
   });
 };
 
-const updateSkillDerivedForId = function(section, row_id) {
+const updateSkillDerivedForId = function (section, row_id) {
   const name = `repeating_${section}_${row_id}_skillname`;
   const disciplineinfo = `repeating_${section}_${row_id}_skilldisciplineinfo`;
   const expertise = `repeating_${section}_${row_id}_skillexpertise`;
@@ -924,7 +945,7 @@ const updateSkillDerivedForId = function(section, row_id) {
   const devout = 'advantage_devout_count';
   getAttrs([name, disciplineinfo, expertise, disciplineexpertise,
     attribute, base, 'IQ', 'DX', mage, devout],
-  function(values) {
+  function (values) {
     // Update TP and CP costs
     let update = {};
     if (values[disciplineinfo] === 'D') {
@@ -946,7 +967,7 @@ const updateSkillDerivedForId = function(section, row_id) {
       update[tp] = cost === 0 ? ' ' : cost;
       update[cp] = ' ';
       // Fix illegal values for expertise of discipline.
-      if ({'ST': true, '-1': true, '0': true}[values[expertise]]) {
+      if ({ 'ST': true, '-1': true, '0': true }[values[expertise]]) {
         update[expertise] = '--';
       }
     } else {
@@ -968,7 +989,7 @@ const updateSkillDerivedForId = function(section, row_id) {
       update[tp] = ' ';
       update[cp] = cost === 0 ? ' ' : cost;
       // Clear base if it is 0.
-      if (values[base] == '0') {
+      if (values[base] === '0') {
         update[base] = ' ';
       }
       // Update ability
@@ -979,12 +1000,12 @@ const updateSkillDerivedForId = function(section, row_id) {
         Number(disciplineexpertise_v));
       const IQ_n = Number(values['IQ']);
       const DX_n = Number(values['DX']);
-      if (attribute_v == '') {
+      if (attribute_v === '') {
         update[ability] = '??';
       } else {
         update[ability] = (
-          (attribute_v == 'IQ' ? IQ_n :
-            attribute_v == 'DX' ? DX_n :
+          (attribute_v === 'IQ' ? IQ_n :
+            attribute_v === 'DX' ? DX_n :
               IQ_n + DX_n) +
             (section === 'arcane' ?
               Number(values[mage]) * 2 :
@@ -993,7 +1014,7 @@ const updateSkillDerivedForId = function(section, row_id) {
                 0) +
             Number(values[base]) +
             disciplineexpertise_n +
-            (expertise_v == 'ST' ? -1 :
+            (expertise_v === 'ST' ? -1 :
               expertise_v !== '--' ? Number(expertise_v) :
                 disciplineexpertise_n === 0 ? -5 : -2));
       }
@@ -1002,7 +1023,7 @@ const updateSkillDerivedForId = function(section, row_id) {
   });
 };
 
-const updateSkillDerived = function(section, event) {
+const updateSkillDerived = function (section, event) {
   const row_id = event.sourceAttribute.split('_')[2];
   updateSkillDerivedForId(section, row_id);
   updateTotalTP(section, 'skill');
@@ -1010,7 +1031,7 @@ const updateSkillDerived = function(section, event) {
 };
 
 const updateAllSkillsDerived = function (section) {
-  getSectionIDs(section, function(ids) {
+  getSectionIDs(section, function (ids) {
     for (let i = 0; i < ids.length; ++i) {
       updateSkillDerivedForId(section, ids[i]);
     }
@@ -1020,21 +1041,21 @@ const updateAllSkillsDerived = function (section) {
 };
 
 on('change:repeating_skill:skilldisciplineinfo' +
-    ' change:repeating_skill:skillexpertise' +
-    ' change:repeating_skill:skillname' + // Fires for new skill.
-    ' remove:repeating_skill' +
-    ' change:_reporder:skill',
-function() { updateSkillDisciplineExpertises('skill'); });
+  ' change:repeating_skill:skillexpertise' +
+  ' change:repeating_skill:skillname' + // Fires for new skill.
+  ' remove:repeating_skill' +
+  ' change:_reporder:skill',
+function () { updateSkillDisciplineExpertises('skill'); });
 
 on('change:repeating_skill:skilldisciplineinfo' +
-    ' change:repeating_skill:skillexpertise' +
-    ' change:repeating_skill:skilldisciplineexpertise' +
-    ' change:repeating_skill:skillattribute' +
-    ' change:repeating_skill:skillbase',
+  ' change:repeating_skill:skillexpertise' +
+  ' change:repeating_skill:skilldisciplineexpertise' +
+  ' change:repeating_skill:skillattribute' +
+  ' change:repeating_skill:skillbase',
 function (event) { updateSkillDerived('skill', event); });
 
-on(  'change:IQ change:DX change:advantage_mage_count'
-    + ' change:advantage_devout_count', 
+on('change:IQ change:DX change:advantage_mage_count'
+  + ' change:advantage_devout_count',
 function () { updateAllSkillsDerived('skill'); });
 
 on('remove:repeating_skill',
@@ -1082,7 +1103,7 @@ const updateArmorValue = function () {
   const reactionPenaltyName = 'reaction_penalty';
   getLargestWeaponDefense((largestWeaponDefense) => {
     getAttrs([armorName, shieldName, defenseBoostName, defendName, reactionPenaltyName],
-      function(values) {
+      function (values) {
         const cur_armor = getValidNumber(values[armorName]);
         const cur_shield = getValidNumber(values[shieldName]);
         const cur_defend = getValidNumber(values[defendName]);
@@ -1112,7 +1133,7 @@ const updateArmorValue = function () {
   });
 };
 on('change:armor_defense change:shield_defense change:defend' +
-  ' change:repeating_weapon:weaponcount' + 
+  ' change:repeating_weapon:weaponcount' +
   ' change:repeating_weapon:weapondefense remove:repeating_weapon' +
   ' change:defense_boost change:reaction_penalty sheet:opened',
 updateArmorValue);
@@ -1121,49 +1142,51 @@ const updateSpeed = function () {
   const DX = 'DX';
   const fast = 'advantage_fast_count';
   const penalty = 'weight_penalty';
-  getAttrs([DX, fast, penalty], function(values) {
+  getAttrs([DX, fast, penalty], function (values) {
     const effective_DX = (Number(values[DX])
-                            + Number(values[fast]));
+      + Number(values[fast]));
     const penalty_n = Number(values[penalty]);
     const DX_reduction = Math.max(0, Math.min(effective_DX,
-      Math.floor(-penalty_n/2)));
-    setAttrs({'speed':
-                Math.max(0, 6 + effective_DX + penalty_n - DX_reduction)});
+      Math.floor(-penalty_n / 2)));
+    setAttrs({
+      'speed':
+        Math.max(0, 6 + effective_DX + penalty_n - DX_reduction)
+    });
   });
 };
 on('change:dx change:advantage_fast_count'
-    + ' change:weight_penalty sheet:opened',
+  + ' change:weight_penalty sheet:opened',
 updateSpeed);
 
 const updateInitiative = function () {
   const IQ = 'IQ';
   const alert = 'advantage_alert_count';
-  getAttrs([IQ, alert], function(values) {
+  getAttrs([IQ, alert], function (values) {
     const effective_IQ = (Number(values[IQ])
-                            + Number(values[alert]));
-    setAttrs({'initiative': effective_IQ});
+      + Number(values[alert]));
+    setAttrs({ 'initiative': effective_IQ });
   });
 };
 on('change:iq change:advantage_alert_count'
-    + ' sheet:opened',
+  + ' sheet:opened',
 updateInitiative);
 
-const updateWeightPenalties = function() {
+const updateWeightPenalties = function () {
   const weight = 'equipment_total_weight';
   const BR = 'BR';
   const packmule = 'advantage_packmule_count';
-  const highlight = function(penalty) {
+  const highlight = function (penalty) {
     return `highlight_weight_penalty_${penalty}`;
   };
-  getAttrs([weight, BR, packmule], function(values) {
+  getAttrs([weight, BR, packmule], function (values) {
     const weight_n = convertToFloat(values[weight]);
     const effective_BR = (Number(values[BR])
-                            + Number(values[packmule]));
+      + Number(values[packmule]));
     let current_level = 0;
     let update = {};
     for (let level = 1; level <= 6; ++level) {
-      const limit = Math.round(((level*level-1)*12/7 + 8.333)
-                                 * 3 * 2**(effective_BR/3));
+      const limit = Math.round(((level * level - 1) * 12 / 7 + 8.333)
+        * 3 * 2 ** (effective_BR / 3));
       if (weight_n >= limit) { current_level = level; }
       update[`penalty_weight_${level}`] = limit;
       update[highlight(level)] = '0';
@@ -1181,45 +1204,45 @@ const updateWeightPenalties = function() {
   });
 };
 on('change:equipment_total_weight' +
-    ' change:br' +
-    ' change:advantage_packmule_count' +
-    ' sheet:opened',
+  ' change:br' +
+  ' change:advantage_packmule_count' +
+  ' sheet:opened',
 updateWeightPenalties);
 
-const updateTotalX = function(x) {
+const updateTotalX = function (x) {
   const armor = `armor_${x}`;
   const shield = `shield_${x}`;
   const weapons = `weapon_total_${x}`;
   const items = `item_total_${x}`;
-  getAttrs([armor, shield, weapons, items], function(values) {
-    let update ={};
+  getAttrs([armor, shield, weapons, items], function (values) {
+    let update = {};
     update[`equipment_total_${x}`] = roundToTwoPlaces(
       convertToFloat(values[armor]) + convertToFloat(values[shield]) +
-              convertToFloat(values[weapons]) + convertToFloat(values[items]));
+      convertToFloat(values[weapons]) + convertToFloat(values[items]));
     setAttrs(update);
   });
 };
 
 on('change:armor_weight change:shield_weight' +
-    ' change:weapon_total_weight change:item_total_weight',
-function() { updateTotalX('weight'); });
+  ' change:weapon_total_weight change:item_total_weight',
+function () { updateTotalX('weight'); });
 on('change:armor_value change:shield_value' +
-    ' change:weapon_total_value change:item_total_value',
-function() { updateTotalX('value'); });
+  ' change:weapon_total_value change:item_total_value',
+function () { updateTotalX('value'); });
 
 // Add up the total weight for repeating_<section>:<section><X>
 // and put it in <section>_total_<X>
-const updateTotalRepeatingX = function(section, x) {
-  getSectionIDs(section, function(ids) {
+const updateTotalRepeatingX = function (section, x) {
+  getSectionIDs(section, function (ids) {
     const x_fields = ids.map(
       id => `repeating_${section}_${id}_${section}${x}`);
     const count_fields = ids.map(
       id => `repeating_${section}_${id}_${section}count`);
-    getAttrs(x_fields.concat(count_fields), function(values) {
+    getAttrs(x_fields.concat(count_fields), function (values) {
       let total = 0;
       for (let i = 0; i < ids.length; ++i) {
         total += (convertToFloat(values[x_fields[i]])
-                    * convertToFloat(values[count_fields[i]]));
+          * convertToFloat(values[count_fields[i]]));
       }
       let update = {};
       update[`${section}_total_${x}`] = total;
@@ -1229,49 +1252,51 @@ const updateTotalRepeatingX = function(section, x) {
 };
 
 on('change:repeating_weapon:weaponweight' +
-    ' change:repeating_weapon:weaponcount' +
-    ' remove:repeating_weapon',
-function() { updateTotalRepeatingX('weapon', 'weight'); });
+  ' change:repeating_weapon:weaponcount' +
+  ' remove:repeating_weapon',
+function () { updateTotalRepeatingX('weapon', 'weight'); });
 on('change:repeating_weapon:weaponvalue' +
-    ' change:repeating_weapon:weaponcount' +
-    ' remove:repeating_weapon',
-function() { updateTotalRepeatingX('weapon', 'value'); });
+  ' change:repeating_weapon:weaponcount' +
+  ' remove:repeating_weapon',
+function () { updateTotalRepeatingX('weapon', 'value'); });
 on('change:repeating_item:itemweight' +
-    ' change:repeating_item:itemcount' +
-    ' remove:repeating_item',
-function() { updateTotalRepeatingX('item', 'weight'); });
+  ' change:repeating_item:itemcount' +
+  ' remove:repeating_item',
+function () { updateTotalRepeatingX('item', 'weight'); });
 on('change:repeating_item:itemvalue' +
-    ' change:repeating_item:itemcount' +
-    ' remove:repeating_item',
-function() { updateTotalRepeatingX('item', 'value'); });
+  ' change:repeating_item:itemcount' +
+  ' remove:repeating_item',
+function () { updateTotalRepeatingX('item', 'value'); });
 
 // -------- Spells ----------
-['arcane','divine', 'innate'].forEach(button => {
-  on(`clicked:${button}`, function() {
-    setAttrs({chosenspelltype: button});
+['arcane', 'divine', 'innate'].forEach(button => {
+  on(`clicked:${button}`, function () {
+    setAttrs({ chosenspelltype: button });
   });
 });
 
 on('change:repeating_arcane:skilldisciplineinfo' +
-    ' change:repeating_arcane:skillexpertise' +
-    ' change:repeating_arcane:skillname' + // Fires for new skill.
-    ' remove:repeating_arcane' +
-    ' change:_reporder:arcane',
-function() { updateSkillDisciplineExpertises('arcane'); });
+  ' change:repeating_arcane:skillexpertise' +
+  ' change:repeating_arcane:skillname' + // Fires for new skill.
+  ' remove:repeating_arcane' +
+  ' change:_reporder:arcane',
+function () { updateSkillDisciplineExpertises('arcane'); });
 
 on('change:repeating_arcane:skilldisciplineinfo' +
-    ' change:repeating_arcane:skillexpertise' +
-    ' change:repeating_arcane:skilldisciplineexpertise' +
-    ' change:repeating_arcane:skillattribute' +
-    ' change:repeating_arcane:skillbase',
+  ' change:repeating_arcane:skillexpertise' +
+  ' change:repeating_arcane:skilldisciplineexpertise' +
+  ' change:repeating_arcane:skillattribute' +
+  ' change:repeating_arcane:skillbase',
 function (event) { updateSkillDerived('arcane', event); });
 
 on('change:IQ change:advantage_mage_count',
   function () { updateAllSkillsDerived('arcane'); });
 
 on('remove:repeating_arcane',
-  function () { updateTotalTP('arcane', 'skill');
-    updateTotalCP('arcane', 'skill');});
+  function () {
+    updateTotalTP('arcane', 'skill');
+    updateTotalCP('arcane', 'skill');
+  });
 
 on('remove:repeating_innate change:repeating_innate:skillCP',
   function () { updateTotalCP('innate', 'skill'); });


### PR DESCRIPTION
Use VSCode auto-formatter + eslint to make code more consistent.

Add `eqeqeq` rule to reduce risks related to JavaScript double equal.