### PR TITLE
Adjust grid headers to allow Ability to grow to fill space

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -754,7 +754,6 @@ body.sheet-darkmode .top-section {
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .top-section .defense-block .epic-table-header-grid.defenses-with-spanning-input {
   color: #fff;
@@ -766,6 +765,8 @@ body.sheet-darkmode .top-section .defense-block .epic-table-header-grid.defenses
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .top-section .defense-block div[data-groupname=repeating_defenses-with-spanning-input] > div,
 .top-section .defense-block div[data-epic-table-name=defenses-with-spanning-input] {
@@ -818,7 +819,6 @@ body.sheet-darkmode .top-section .defense-block .epic-table-header-grid.defenses
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .top-section .defense-block .epic-table-header-grid.defenses {
   color: #fff;
@@ -830,6 +830,8 @@ body.sheet-darkmode .top-section .defense-block .epic-table-header-grid.defenses
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .top-section .defense-block div[data-groupname=repeating_defenses] > div,
 .top-section .defense-block div[data-epic-table-name=defenses] {
@@ -1089,7 +1091,6 @@ body.sheet-darkmode .weight-penalty-table > div:not(:last-child):not(.table-head
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .overview-tab .advantage-overview .epic-table-header-grid.advantage {
   color: #fff;
@@ -1101,6 +1102,8 @@ body.sheet-darkmode .overview-tab .advantage-overview .epic-table-header-grid.ad
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .overview-tab .advantage-overview div[data-groupname=repeating_advantage] > div,
 .overview-tab .advantage-overview div[data-epic-table-name=advantage] {
@@ -1153,7 +1156,6 @@ body.sheet-darkmode .overview-tab .advantage-overview .epic-table-header-grid.ad
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .overview-tab .advantage-overview .epic-table-header-grid.extraadvantage {
   color: #fff;
@@ -1165,6 +1167,8 @@ body.sheet-darkmode .overview-tab .advantage-overview .epic-table-header-grid.ex
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .overview-tab .advantage-overview div[data-groupname=repeating_extraadvantage] > div,
 .overview-tab .advantage-overview div[data-epic-table-name=extraadvantage] {
@@ -1256,7 +1260,6 @@ body.sheet-darkmode .overview-tab .advantage-overview .extraadvantage-row {
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .overview-tab .feat-overview .epic-table-header-grid.feat {
   color: #fff;
@@ -1268,6 +1271,8 @@ body.sheet-darkmode .overview-tab .feat-overview .epic-table-header-grid.feat {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .overview-tab .feat-overview div[data-groupname=repeating_feat] > div,
 .overview-tab .feat-overview div[data-epic-table-name=feat] {
@@ -1340,7 +1345,6 @@ body.sheet-darkmode .overview-tab .feat-overview > div[data-groupname] > div {
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .overview-tab .skills-overview .epic-table-header-grid.skills-table {
   color: #fff;
@@ -1352,6 +1356,8 @@ body.sheet-darkmode .overview-tab .skills-overview .epic-table-header-grid.skill
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .overview-tab .skills-overview div[data-groupname=repeating_skills-table] > div,
 .overview-tab .skills-overview div[data-epic-table-name=skills-table] {
@@ -1436,7 +1442,6 @@ body.sheet-darkmode .overview-tab .skills-overview > div[data-groupname] .skill-
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .overview-tab .weapons-overview .epic-table-header-grid.weapons-table {
   color: #fff;
@@ -1448,6 +1453,8 @@ body.sheet-darkmode .overview-tab .weapons-overview .epic-table-header-grid.weap
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .overview-tab .weapons-overview div[data-groupname=repeating_weapons-table] > div,
 .overview-tab .weapons-overview div[data-epic-table-name=weapons-table] {
@@ -1500,7 +1507,6 @@ body.sheet-darkmode .overview-tab .weapons-overview .epic-table-header-grid.weap
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .overview-tab .weapons-overview .epic-table-header-grid.weapons-equipmentnotes-table {
   color: #fff;
@@ -1512,6 +1518,8 @@ body.sheet-darkmode .overview-tab .weapons-overview .epic-table-header-grid.weap
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .overview-tab .weapons-overview div[data-groupname=repeating_weapons-equipmentnotes-table] > div,
 .overview-tab .weapons-overview div[data-epic-table-name=weapons-equipmentnotes-table] {
@@ -1603,7 +1611,6 @@ body.sheet-darkmode .overview-tab .weapons-overview > div[data-groupname] .weapo
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .basic-tab .character-attributes .epic-table-header-grid.character-attributes {
   color: #fff;
@@ -1615,6 +1622,8 @@ body.sheet-darkmode .basic-tab .character-attributes .epic-table-header-grid.cha
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .basic-tab .character-attributes div[data-groupname=repeating_character-attributes] > div,
 .basic-tab .character-attributes div[data-epic-table-name=character-attributes] {
@@ -1690,7 +1699,6 @@ body.sheet-darkmode .basic-tab .character-attributes div[data-epic-table-name=ch
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .basic-tab .advantages .epic-table-header-grid.advantage {
   color: #fff;
@@ -1702,6 +1710,8 @@ body.sheet-darkmode .basic-tab .advantages .epic-table-header-grid.advantage {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .basic-tab .advantages div[data-groupname=repeating_advantage] > div,
 .basic-tab .advantages div[data-epic-table-name=advantage] {
@@ -1769,7 +1779,6 @@ body.sheet-darkmode .basic-tab .advantages div[data-epic-table-name=advantage] +
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .basic-tab .advantages .epic-table-header-grid.extraadvantage {
   color: #fff;
@@ -1781,6 +1790,8 @@ body.sheet-darkmode .basic-tab .advantages .epic-table-header-grid.extraadvantag
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .basic-tab .advantages div[data-groupname=repeating_extraadvantage] > div,
 .basic-tab .advantages div[data-epic-table-name=extraadvantage] {
@@ -1883,7 +1894,6 @@ body.sheet-darkmode .basic-tab .advantages .epic-table-header-grid .skillCP-grid
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .basic-tab .feats .epic-table-header-grid.feat {
   color: #fff;
@@ -1895,6 +1905,8 @@ body.sheet-darkmode .basic-tab .feats .epic-table-header-grid.feat {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .basic-tab .feats div[data-groupname=repeating_feat] > div,
 .basic-tab .feats div[data-epic-table-name=feat] {
@@ -1996,7 +2008,6 @@ body.sheet-darkmode .basic-tab .feats .epic-table-header-grid .skillCP-grid, bod
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .epic-skills-tab .epic-table-header-grid.skill {
   color: #fff;
@@ -2008,6 +2019,8 @@ body.sheet-darkmode .epic-skills-tab .epic-table-header-grid.skill {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .epic-skills-tab div[data-groupname=repeating_skill] > div,
 .epic-skills-tab div[data-epic-table-name=skill] {
@@ -2151,7 +2164,6 @@ body.sheet-darkmode .epic-skills-tab button.add-base-skills-button, body.sheet-d
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .equipment-tab .epic-table-header-grid.armor {
   color: #fff;
@@ -2163,6 +2175,8 @@ body.sheet-darkmode .equipment-tab .epic-table-header-grid.armor {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .equipment-tab div[data-groupname=repeating_armor] > div,
 .equipment-tab div[data-epic-table-name=armor] {
@@ -2230,7 +2244,6 @@ body.sheet-darkmode .equipment-tab div[data-epic-table-name=armor] + div[data-ep
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .equipment-tab .epic-table-header-grid.shield {
   color: #fff;
@@ -2242,6 +2255,8 @@ body.sheet-darkmode .equipment-tab .epic-table-header-grid.shield {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .equipment-tab div[data-groupname=repeating_shield] > div,
 .equipment-tab div[data-epic-table-name=shield] {
@@ -2309,7 +2324,6 @@ body.sheet-darkmode .equipment-tab div[data-epic-table-name=shield] + div[data-e
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .equipment-tab .epic-table-header-grid.weapon {
   color: #fff;
@@ -2321,6 +2335,8 @@ body.sheet-darkmode .equipment-tab .epic-table-header-grid.weapon {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .equipment-tab div[data-groupname=repeating_weapon] > div,
 .equipment-tab div[data-epic-table-name=weapon] {
@@ -2388,7 +2404,6 @@ body.sheet-darkmode .equipment-tab div[data-epic-table-name=weapon] + div[data-e
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .equipment-tab .epic-table-header-grid.item {
   color: #fff;
@@ -2400,6 +2415,8 @@ body.sheet-darkmode .equipment-tab .epic-table-header-grid.item {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .equipment-tab div[data-groupname=repeating_item] > div,
 .equipment-tab div[data-epic-table-name=item] {
@@ -2552,13 +2569,12 @@ body.sheet-darkmode .spells .spellNotesPopover button.popoverButton {
 }
 .spells .epic-table-header-grid.arcane {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 40px) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 80px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 16px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 4fr) minmax(0, 1fr) minmax(0, 40px) minmax(0, 20px) minmax(0, 40px) minmax(0, 1fr) minmax(0, 80px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 20px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
   column-gap: 2px;
   color: #fff;
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .spells .epic-table-header-grid.arcane {
   color: #fff;
@@ -2570,11 +2586,13 @@ body.sheet-darkmode .spells .epic-table-header-grid.arcane {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .spells div[data-groupname=repeating_arcane] > div,
 .spells div[data-epic-table-name=arcane] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 4fr) minmax(0, 32px) minmax(0, 40px) minmax(0, 0.5fr) minmax(0, 40px) minmax(0, 1fr) minmax(0, 80px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 16px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 4fr) minmax(0, 1fr) minmax(0, 40px) minmax(0, 20px) minmax(0, 40px) minmax(0, 1fr) minmax(0, 80px) minmax(0, 1.5fr) minmax(0, 2fr) minmax(0, 1.5fr) minmax(0, 20px) minmax(0, 24px) minmax(0, 24px) minmax(0, 40px) minmax(0, auto) minmax(0, 40px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -2646,13 +2664,12 @@ body.sheet-darkmode .spells div[data-epic-table-name=arcane] + div[data-epic-tab
 }
 .spells .epic-table-header-grid.divine {
   display: grid;
-  grid-template-columns: minmax(0, 6fr) minmax(0, 16px) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
+  grid-template-columns: minmax(0, 6fr) minmax(0, 20px) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
   column-gap: 2px;
   color: #fff;
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .spells .epic-table-header-grid.divine {
   color: #fff;
@@ -2664,11 +2681,13 @@ body.sheet-darkmode .spells .epic-table-header-grid.divine {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .spells div[data-groupname=repeating_divine] > div,
 .spells div[data-epic-table-name=divine] {
   display: grid;
-  grid-template-columns: minmax(0, 6fr) minmax(0, 16px) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
+  grid-template-columns: minmax(0, 6fr) minmax(0, 20px) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr) minmax(0, 2fr);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;
@@ -2725,13 +2744,12 @@ body.sheet-darkmode .spells div[data-epic-table-name=divine] + div[data-epic-tab
 }
 .spells .epic-table-header-grid.innate {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 6fr) minmax(0, 16px) minmax(0, 32px) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 6fr) minmax(0, 20px) minmax(0, 32px) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
   column-gap: 2px;
   color: #fff;
   background-color: #b56632;
   padding: 0 2px;
   margin-bottom: 2px;
-  word-break: break-word;
 }
 body.sheet-darkmode .spells .epic-table-header-grid.innate {
   color: #fff;
@@ -2743,11 +2761,13 @@ body.sheet-darkmode .spells .epic-table-header-grid.innate {
   text-align: center;
   margin: auto;
   font-weight: bold;
+  width: 100%;
+  overflow: hidden;
 }
 .spells div[data-groupname=repeating_innate] > div,
 .spells div[data-epic-table-name=innate] {
   display: grid;
-  grid-template-columns: minmax(0, 40px) minmax(0, 6fr) minmax(0, 16px) minmax(0, 32px) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
+  grid-template-columns: minmax(0, 40px) minmax(0, 6fr) minmax(0, 20px) minmax(0, 32px) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr) minmax(0, 32px);
   row-gap: 0;
   column-gap: 2px;
   background: transparent;

--- a/bin/main.html
+++ b/bin/main.html
@@ -982,7 +982,7 @@
           <div class="spellrange-grid">Range</div>
           <div class="spelltarget-grid">Target</div>
           <div class="spellduration-grid">Damage/ Duration</div>
-          <div class="spellhasnote-grid">N</div>
+          <div class="spellhasnote-grid">Notes</div>
           <div class="skillFP-grid">FP</div>
           <div class="skillCP-grid">CP</div>
           <div class="skillexpertise-grid">Exper.</div>
@@ -1092,7 +1092,7 @@
         <input name="attr_divine_total_single_CP" type="hidden" value="0" />
         <div class="divine epic-table-header-grid">
           <div class="skillname-grid">Name</div>
-          <div class="spellhasnote-grid">N</div>
+          <div class="spellhasnote-grid">Notes</div>
           <div class="spellEP-grid">EP</div>
           <div class="spellcasttime-grid">Cast Time</div>
           <div class="spelltype-grid">Touch/ Ray/ Missile</div>
@@ -1166,10 +1166,10 @@
         <input name="attr_innate_total_CP" type="hidden" value="0" />
         <input name="attr_innate_total_single_CP" type="hidden" value="0" />
         <div class="innate epic-table-header-grid">
-          <div class="skill-innatesphere-grid epic-tooltip">Sph<span class="epic-tooltip-text">Spell Sphere</span>
+          <div class="skill-innatesphere-grid epic-tooltip">Sphere<span class="epic-tooltip-text">Spell Sphere</span>
           </div>
           <div class="skillname-grid">Name</div>
-          <div class="spellhasnote-grid">N</div>
+          <div class="spellhasnote-grid">Notes</div>
           <div class="spellEP-grid">EP</div>
           <div class="spellcasttime-grid">Cast Time</div>
           <div class="spelltype-grid">Touch/ Ray/ Missile</div>

--- a/ui/components/gridTable/gridTable.scss
+++ b/ui/components/gridTable/gridTable.scss
@@ -11,11 +11,12 @@ $grid-column-gap: 2px;
   @include theme-background-color(primary-highlight-background-color);
   padding: 0 $grid-padding;
   margin-bottom: $grid-padding;
-  word-break: break-word;
   > div {
     text-align: center;
     margin: auto;
     font-weight: bold;
+    width: 100%;
+    overflow: hidden;
   }
 }
 

--- a/ui/spells/spells.pug
+++ b/ui/spells/spells.pug
@@ -47,7 +47,7 @@
       .spellrange-grid Range
       .spelltarget-grid Target
       .spellduration-grid Damage/ Duration
-      .spellhasnote-grid N
+      .spellhasnote-grid Notes
       .skillFP-grid FP
       .skillCP-grid CP
       .skillexpertise-grid Exper.
@@ -104,7 +104,7 @@
     input(name='attr_divine_total_single_CP' type='hidden' value='0')
     .divine.epic-table-header-grid
       .skillname-grid Name
-      .spellhasnote-grid N
+      .spellhasnote-grid Notes
       .spellEP-grid EP
       .spellcasttime-grid Cast Time
       .spelltype-grid Touch/ Ray/ Missile
@@ -128,10 +128,10 @@
     input(name='attr_innate_total_CP' type='hidden' value='0')
     input(name='attr_innate_total_single_CP' type='hidden' value='0')
     .innate.epic-table-header-grid
-      .skill-innatesphere-grid.epic-tooltip Sph
+      .skill-innatesphere-grid.epic-tooltip Sphere
         span.epic-tooltip-text Spell Sphere
       .skillname-grid Name
-      .spellhasnote-grid N
+      .spellhasnote-grid Notes
       .spellEP-grid EP
       .spellcasttime-grid Cast Time
       .spelltype-grid Touch/ Ray/ Missile

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -19,7 +19,7 @@
   display: block;
 }
 
-$notes-popover-width: 16px;
+$notes-popover-width: 20px;
 .spell-tabs {
 
   border-bottom: solid 1px;
@@ -49,11 +49,11 @@ $notes-popover-width: 16px;
   @import './spellsNotesPopover.scss';
 
   $arcane-grid-template: getResponsiveGridWidths(
-    40px, // Discipline?
+    1fr, // Discipline?
     4fr, // Name
-    32px, // Ability
+    1fr, // Ability
     40px, // Mod
-    0.5fr, // (Dice)
+    20px, // (Dice)
     40px, // EP
     1fr, // Cast Time
     80px, // Touch/ Ray/ Missile - 80px for two rows not three


### PR DESCRIPTION
Summary
===
The Spell -> Ability column was a fixed width, and always wrapped the string.

> The word "Ability" on the Arcane spellcasting tab never expands enough to show the whole word on one line:
![image](https://github.com/epic-power-rpg/roll20/assets/5629800/1631a82f-7d09-4bd5-894c-a2257745d722)

Changes
===
- Make `Ability` column use fractional width
- Adjust other columns to fix width
- Change grid style to not break words, but rather to fill as much as they can in the header, without overflowing.
- Update shortened strings - `Sph` -> `Sphere`, and `N` -> `Notes`

Screenies
---

| Old | New |
| ---- | ---- |
| ![image](https://github.com/epic-power-rpg/roll20/assets/5629800/4e8934d1-f4ee-41e6-9be4-49a383a193ae) | ![image](https://github.com/epic-power-rpg/roll20/assets/5629800/ac75ae8c-238c-4514-a71c-68436c0e7e9a) |
| ![image](https://github.com/epic-power-rpg/roll20/assets/5629800/9853e551-c53c-4b37-a672-58a8c6ff2b04) | ![image](https://github.com/epic-power-rpg/roll20/assets/5629800/6032d7a0-c29d-4b36-b056-967129a48bcd) |
| ![image](https://github.com/epic-power-rpg/roll20/assets/5629800/d2206924-0d08-4497-a1f2-1ea856dc0647) | ![image](https://github.com/epic-power-rpg/roll20/assets/5629800/b843f4c7-92c8-45e6-be39-38b0eaa533fa) |
| ![image](https://github.com/epic-power-rpg/roll20/assets/5629800/2fc5407c-8856-4ea6-ad42-1f8b433a917f) | ![image](https://github.com/epic-power-rpg/roll20/assets/5629800/654c06f2-706d-40cc-a11d-9b8019cbd1cb) |
