### PR TITLE
Base unarmed attack on br+dx

### DIFF
--- a/bin/main.html
+++ b/bin/main.html
@@ -2462,8 +2462,8 @@ on('change:repeating_skill:skilldisciplineinfo' +
   ' change:repeating_skill:skillbase',
 function (event) { updateSkillDerived('skill', event); });
 
-on('change:IQ change:DX change:advantage_mage_count'
-  + ' change:advantage_devout_count',
+on('change:IQ change:DX change:BR'
+  + ' change:advantage_mage_count change:advantage_devout_count',
 function () { updateAllSkillsDerived('skill'); });
 
 on('remove:repeating_skill',

--- a/bin/main.html
+++ b/bin/main.html
@@ -801,6 +801,7 @@
             <option value="DX">DX</option>
             <option value="IQ+DX">IQ+DX</option>
             <option value="BR">BR</option>
+            <option value="BR+DX">BR+DX</option>
           </select>
           <input class="skillbase-grid" name="attr_skillbase" type="number" value="" />
         </fieldset>

--- a/bin/main.html
+++ b/bin/main.html
@@ -2409,7 +2409,8 @@ const updateSkillDerivedForId = function (section, row_id) {
           attribute_v === 'IQ' ? IQ_n :
           attribute_v === 'DX' ? DX_n :
           attribute_v === 'BR' ? BR_n :
-          IQ_n + DX_n);
+          attribute_v === 'IQ+DX' ? IQ_n + DX_n :
+          BR_n + DX_n);
         const focus = (
           expertise_v === 'ST' ? -1 :
           expertise_v === 'B' ? -1 :
@@ -2494,18 +2495,27 @@ function createBaseSkillsAttributes(includePersonal) {
       ...props,
     });
   }
+  function addNewSkillWithNoDiscipline(skillname, props) {
+    addNewAttributeRow({
+      skilldisciplineinfo: '',
+      skillname,
+      ...props,
+    });
+  }
   if (includePersonal) {
+    addNewSkillWithNoDiscipline('Language (Common)', { skillattribute: 'IQ', skillexpertise: 'ST', skillBase: 2});
     addNewDiscipline('People');
-    addNewSkill('Language (Common)', { skillattribute: 'IQ', skillexpertise: 'ST' });
+    addNewSkill('Manners (Common)', { skillattribute: 'IQ', skillexpertise: 'ST', skillBase: 2});
     addNewSkill('Persuade', { skillattribute: 'IQ', skillexpertise: 'ST' });
     addNewSkill('People Insight', { skillattribute: 'IQ', skillexpertise: 'ST', skillBase: 1 });
   }
   addNewDiscipline('Defense', { skillexpertise: 1 });
   addNewSkill('Dodge', { skillattribute: 'DX', skillexpertise: 'ST', skillbase: -3 });
   addNewSkill('Resolve', { skillattribute: 'IQ', skillexpertise: 'ST', skillbase: 0 });
-  addNewSkill('Fortitude', { skillattribute: 'BR', skillexpertise: 'ST', skillbase: 0 });
+  addNewSkill('Robustness', { skillattribute: 'BR', skillexpertise: 'ST', skillbase: 0 });
   addNewDiscipline('Attack', { skillexpertise: 1 });
   addNewSkill('Your Weapon', { skillattribute: 'DX', skillexpertise: '1', skillbase: 0 });
+  addNewSkill('Unarmed', { skillattribute: 'BR+DX', skillexpertise: 'ST', skillbase: 0 });
   return newAttributes;
 }
 

--- a/bin/main.html
+++ b/bin/main.html
@@ -2515,7 +2515,7 @@ function createBaseSkillsAttributes(includePersonal) {
   addNewSkill('Robustness', { skillattribute: 'BR', skillexpertise: 'ST', skillbase: 0 });
   addNewDiscipline('Attack', { skillexpertise: 1 });
   addNewSkill('Your Weapon', { skillattribute: 'DX', skillexpertise: '1', skillbase: 0 });
-  addNewSkill('Unarmed', { skillattribute: 'BR+DX', skillexpertise: 'ST', skillbase: 0 });
+  addNewSkill('Unarmed', { skillattribute: 'BR+DX', skillexpertise: 'ST', skillbase: -1 });
   return newAttributes;
 }
 

--- a/ui/epicSkills/epicSkills.pug
+++ b/ui/epicSkills/epicSkills.pug
@@ -48,6 +48,7 @@
         option(value='DX') DX
         option(value='IQ+DX') IQ+DX
         option(value='BR') BR
+        option(value='BR+DX') BR+DX
       input.skillbase-grid(name='attr_skillbase' type='number' value='')
   .add-base-skills-section
     input.skill-count-control(name='attr_skillCount' type='hidden' value="")

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1121,7 +1121,8 @@ const updateSkillDerivedForId = function (section, row_id) {
           attribute_v === 'IQ' ? IQ_n :
           attribute_v === 'DX' ? DX_n :
           attribute_v === 'BR' ? BR_n :
-          IQ_n + DX_n);
+          attribute_v === 'IQ+DX' ? IQ_n + DX_n :
+          BR_n + DX_n);
         const focus = (
           expertise_v === 'ST' ? -1 :
           expertise_v === 'B' ? -1 :
@@ -1206,18 +1207,27 @@ function createBaseSkillsAttributes(includePersonal) {
       ...props,
     });
   }
+  function addNewSkillWithNoDiscipline(skillname, props) {
+    addNewAttributeRow({
+      skilldisciplineinfo: '',
+      skillname,
+      ...props,
+    });
+  }
   if (includePersonal) {
+    addNewSkillWithNoDiscipline('Language (Common)', { skillattribute: 'IQ', skillexpertise: 'ST', skillBase: 2});
     addNewDiscipline('People');
-    addNewSkill('Language (Common)', { skillattribute: 'IQ', skillexpertise: 'ST' });
+    addNewSkill('Manners (Common)', { skillattribute: 'IQ', skillexpertise: 'ST', skillBase: 2});
     addNewSkill('Persuade', { skillattribute: 'IQ', skillexpertise: 'ST' });
     addNewSkill('People Insight', { skillattribute: 'IQ', skillexpertise: 'ST', skillBase: 1 });
   }
   addNewDiscipline('Defense', { skillexpertise: 1 });
   addNewSkill('Dodge', { skillattribute: 'DX', skillexpertise: 'ST', skillbase: -3 });
   addNewSkill('Resolve', { skillattribute: 'IQ', skillexpertise: 'ST', skillbase: 0 });
-  addNewSkill('Fortitude', { skillattribute: 'BR', skillexpertise: 'ST', skillbase: 0 });
+  addNewSkill('Robustness', { skillattribute: 'BR', skillexpertise: 'ST', skillbase: 0 });
   addNewDiscipline('Attack', { skillexpertise: 1 });
   addNewSkill('Your Weapon', { skillattribute: 'DX', skillexpertise: '1', skillbase: 0 });
+  addNewSkill('Unarmed', { skillattribute: 'BR+DX', skillexpertise: 'ST', skillbase: 0 });
   return newAttributes;
 }
 

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1174,8 +1174,8 @@ on('change:repeating_skill:skilldisciplineinfo' +
   ' change:repeating_skill:skillbase',
 function (event) { updateSkillDerived('skill', event); });
 
-on('change:IQ change:DX change:advantage_mage_count'
-  + ' change:advantage_devout_count',
+on('change:IQ change:DX change:BR'
+  + ' change:advantage_mage_count change:advantage_devout_count',
 function () { updateAllSkillsDerived('skill'); });
 
 on('remove:repeating_skill',

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1227,7 +1227,7 @@ function createBaseSkillsAttributes(includePersonal) {
   addNewSkill('Robustness', { skillattribute: 'BR', skillexpertise: 'ST', skillbase: 0 });
   addNewDiscipline('Attack', { skillexpertise: 1 });
   addNewSkill('Your Weapon', { skillattribute: 'DX', skillexpertise: '1', skillbase: 0 });
-  addNewSkill('Unarmed', { skillattribute: 'BR+DX', skillexpertise: 'ST', skillbase: 0 });
+  addNewSkill('Unarmed', { skillattribute: 'BR+DX', skillexpertise: 'ST', skillbase: -1 });
   return newAttributes;
 }
 


### PR DESCRIPTION
I'm trying to simplify the grappling rules, so they agree better with how we've been playing them, and make a bit more sense, besides. Part of that requires making Unarmed Attack be based on BR+DX, rather than just DX. ('cause when some big monster with BR 8 is grappling with you, their BR should weigh in.

While I was messing in this space, I also caught character creation up with the rules:
  Unarmed Attack is a default skill.
  Language is no longer under the People discipline, and has a base of IQ+2.
  Manners is a default skill.
  Fortitude is renamed to Robustness.