### PR TITLE
Fix the CP cost of attributes that were adjusted for a species.

### DIFF
--- a/bin/main.html
+++ b/bin/main.html
@@ -1812,13 +1812,24 @@ on('change:cp sheet:opened', updateFP);
 // ----- Attribute costs -----
 const updateAttributeCost = function () {
   getAttrs(['IQ', 'DX', 'BR'], function (attributes) {
-    const IQ = Number(attributes.IQ);
-    const DX = Number(attributes.DX);
-    const BR = Number(attributes.BR);
-    const total = IQ + DX + BR;
-    const total_squares = IQ ** 2 + DX ** 2 + BR ** 2;
+    const values = [Number(attributes.IQ),
+                        Number(attributes.DX),
+                        Number(attributes.BR)]
+    values.sort((a,b) => a - b);
+    var total = values.reduce((acc, x) => acc + x);
+    // The total is normally 3, but not if a species adjusts it.
+    // Get the unadjusted values, making the most charitable assumption.
+    if (total == 2) {
+      // Maybe an attribute got reduced. Assume it was the lowest one.
+      values[0] += 1;
+    } else if (total == 4) {
+      // Maybe an attribute got increased. Assume it was the highest one.
+      values[2] -= 1;
+    }
+    total = values.reduce((acc, x) => acc + x);
     let cost = '??';
     if (total === 3) {
+      const total_squares = values.reduce((acc, x) => acc + x**2, 0);
       if (total_squares === 3) {
         cost = -2;
       } else if (total_squares === 5) {

--- a/bin/main.html
+++ b/bin/main.html
@@ -1816,13 +1816,13 @@ const updateAttributeCost = function () {
                         Number(attributes.DX),
                         Number(attributes.BR)]
     values.sort((a,b) => a - b);
-    var total = values.reduce((acc, x) => acc + x);
+    let total = values.reduce((acc, x) => acc + x);
     // The total is normally 3, but not if a species adjusts it.
     // Get the unadjusted values, making the most charitable assumption.
-    if (total == 2) {
+    if (total === 2) {
       // Maybe an attribute got reduced. Assume it was the lowest one.
       values[0] += 1;
-    } else if (total == 4) {
+    } else if (total === 4) {
       // Maybe an attribute got increased. Assume it was the highest one.
       values[2] -= 1;
     }

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -521,7 +521,7 @@ const updateAttributeCost = function () {
                         Number(attributes.DX),
                         Number(attributes.BR)]
     values.sort((a,b) => a - b);
-    var total = values.reduce((acc, x) => acc + x);
+    let total = values.reduce((acc, x) => acc + x);
     // The total is normally 3, but not if a species adjusts it.
     // Get the unadjusted values, making the most charitable assumption.
     if (total === 2) {

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -524,7 +524,7 @@ const updateAttributeCost = function () {
     var total = values.reduce((acc, x) => acc + x);
     // The total is normally 3, but not if a species adjusts it.
     // Get the unadjusted values, making the most charitable assumption.
-    if (total == 2) {
+    if (total === 2) {
       // Maybe an attribute got reduced. Assume it was the lowest one.
       values[0] += 1;
     } else if (total == 4) {

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -517,13 +517,24 @@ on('change:cp sheet:opened', updateFP);
 // ----- Attribute costs -----
 const updateAttributeCost = function () {
   getAttrs(['IQ', 'DX', 'BR'], function (attributes) {
-    const IQ = Number(attributes.IQ);
-    const DX = Number(attributes.DX);
-    const BR = Number(attributes.BR);
-    const total = IQ + DX + BR;
-    const total_squares = IQ ** 2 + DX ** 2 + BR ** 2;
+    const values = [Number(attributes.IQ),
+                        Number(attributes.DX),
+                        Number(attributes.BR)]
+    values.sort((a,b) => a - b);
+    var total = values.reduce((acc, x) => acc + x);
+    // The total is normally 3, but not if a species adjusts it.
+    // Get the unadjusted values, making the most charitable assumption.
+    if (total == 2) {
+      // Maybe an attribute got reduced. Assume it was the lowest one.
+      values[0] += 1;
+    } else if (total == 4) {
+      // Maybe an attribute got increased. Assume it was the highest one.
+      values[2] -= 1;
+    }
+    total = values.reduce((acc, x) => acc + x);
     let cost = '??';
     if (total === 3) {
+      const total_squares = values.reduce((acc, x) => acc + x**2, 0);
       if (total_squares === 3) {
         cost = -2;
       } else if (total_squares === 5) {

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -527,7 +527,7 @@ const updateAttributeCost = function () {
     if (total === 2) {
       // Maybe an attribute got reduced. Assume it was the lowest one.
       values[0] += 1;
-    } else if (total == 4) {
+    } else if (total === 4) {
       // Maybe an attribute got increased. Assume it was the highest one.
       values[2] -= 1;
     }


### PR DESCRIPTION
If the attributes don't add up to 3, assume that is because they were adjusted by a species. Try to guess what the adjustment was, and calculate the CP cost from the pre-adjusted values.