### PR TITLE
Fix number parsing for invalid chars

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -613,6 +613,7 @@ radio > span.checked {
   display: inline-flex;
   flex-direction: column;
   flex-grow: 1;
+  row-gap: 2px;
 }
 
 .roll-description-line {

--- a/bin/main.html
+++ b/bin/main.html
@@ -1487,21 +1487,29 @@ const toggleSavePending = function () {
 };
 on('clicked:saveroll', toggleSavePending);
 
-const numericRollKeys = [
+/**
+ * Ordered list of roll keys (Do not reorganize)
+ */
+const roll_keys = [
+  'action_description',
   'action_feats',
   'action_EP',
   'action_SP',
+  'roll_skill',
   'roll_ability',
   'roll_mod1',
   'roll_mod2',
   'roll_mod3',
   'roll_advance_boost',
 ];
-const roll_keys = [
+const nonUpdateRollSectionKeys = new Set([
   'action_description',
   'roll_skill',
-  ...numericRollKeys,
-];
+  'roll_mod2',
+  'roll_mod3',
+]);
+
+const updateRollSectionNumericRollKeys = roll_keys.filter((key) => !nonUpdateRollSectionKeys.has(key));
 
 const saveRollState = function (key, roll_chosen) {
   getAttrs(roll_keys,
@@ -1565,7 +1573,7 @@ roll_choices.forEach(function (value) {
 
 function updateRollSectionContent({ skillName, description = '', abilityValue, advanceBoost, power }) {
   const baseNumericContent = {};
-  numericRollKeys.forEach((key) => {
+  updateRollSectionNumericRollKeys.forEach((key) => {
     baseNumericContent[key] = 0;
   });
 

--- a/bin/main.html
+++ b/bin/main.html
@@ -848,10 +848,6 @@
         <div>
           <div class="attribute-name larger inline bold right middle">Wt. Pen.</div>
           <span class="narrowish center bold larger value" name="attr_displayed_weight_penalty"></span>
-        </div>
-        <div>
-          <div class="attribute-name larger inline bold right middle">Speed</div>
-          <span class="narrowish center bold larger value" name="attr_speed"></span>
           <span class="speedTooltip">
             <button class="popoverButton circledButton" name="act_popover_weightPenalties" type="action">?</button>
             <input class="sectioncontrol" name="attr_chosenPopover" type="hidden" value="false" />
@@ -901,6 +897,10 @@
               </div>
             </div>
           </span>
+        </div>
+        <div>
+          <div class="attribute-name larger inline bold right middle">Speed</div>
+          <span class="narrowish center bold larger value" name="attr_speed"></span>
         </div>
       </div>
 
@@ -3019,7 +3019,7 @@ const updateWeightPenalties = function () {
     if (current_level === 6) { current_level = 100; }
     update['weight_penalty'] = -current_level;
     update['displayed_weight_penalty'] = (
-      current_level === 0 ? ' ' :
+      current_level === 0 ? '0' :
         current_level === 100 ? '-∞' :
           -current_level);
     setAttrs(update);

--- a/bin/main.html
+++ b/bin/main.html
@@ -1592,12 +1592,12 @@ function updateRollSectionContent({ skillName, description = '', abilityValue, a
       'repeating_spell_spellEP'
     ], (attributes) => {
       const { ['repeating_skill_skillname']: skillName } = attributes;
-      const skillAbility = Number(attributes['repeating_skill_skillability'] ?? 0);
-      const advanceBoost = Number(attributes['repeating_skill_skillmodifier'] ?? 0);
+      const skillAbility = getNumberIfValid(attributes['repeating_skill_skillability']);
+      const advanceBoost = getNumberIfValid(attributes['repeating_skill_skillmodifier']);
       const deityName = attributes['repeating_skill_skill_deity_name'];
       let description = sectionName === 'repeating_divine' && deityName ? `Pray to ${deityName} ` : '';
       const spellPwr = isValueDefined(attributes['repeating_spell_spellEP']) ?
-        Number(attributes['repeating_spell_spellEP'] ?? 0) :
+        getNumberIfValid(attributes['repeating_spell_spellEP']) :
         undefined;
       console.log({skillName, skillAbility, advanceBoost});
       updateRollSectionContent({ skillName, description, abilityValue: skillAbility, advanceBoost, power: spellPwr });
@@ -1683,8 +1683,8 @@ GENERAL_UPDATE_ROLL_SECTION_OPTIONS.forEach((rollOption) => {
   on(`clicked:${actionId}`, () => {
     const { skillAbilityKey, advanceBoostKey } = attributes;
     getAttrs([skillAbilityKey, advanceBoostKey].filter(Boolean), (values) => {
-      const abilityValue = Number(values[skillAbilityKey] ?? 0);
-      const advanceBoost = Number(values[advanceBoostKey] ?? 0);
+      const abilityValue = getNumberIfValid(values[skillAbilityKey]);
+      const advanceBoost = getNumberIfValid(values[advanceBoostKey]);
 
       updateRollSectionContent({ skillName,abilityValue, advanceBoost });
     });
@@ -2202,7 +2202,7 @@ const updateAdvantagesCosts = function () {
             return {
               description_key: prefix + 'CPdescription',
               base_cost: advantageCosts[advantage],
-              count: Number(attributes[prefix + 'count'])
+              count: getNumberIfValid(attributes[prefix + 'count'])
             };
           });
         const extra_advantages = extra_ids.map(
@@ -2210,7 +2210,7 @@ const updateAdvantagesCosts = function () {
             const prefix = 'repeating_extraadvantage_' + extra_id + '_';
             return {
               description_key: prefix + 'extraadvantageCPdescription',
-              base_cost: Number(attributes[prefix + 'extraadvantageCP']),
+              base_cost: getNumberIfValid(attributes[prefix + 'extraadvantageCP']),
               count: 1
             };
           });
@@ -2638,8 +2638,8 @@ function updateDivineAttributes() {
             for (let skillIndex = 0; skillIndex < skillIds.length; ++skillIndex) {
               const skillName = attributes[skillNameFields[skillIndex]];
               if (skillName?.toLowerCase().trim().includes(deityName.toLowerCase().trim())) {
-                const skillAbility = Number(attributes[skillAbilityFields[skillIndex]] || 0);
-                const deityAbility = Number(attributes[deityAbilityFields[i]] || 0);
+                const skillAbility = getNumberIfValid(attributes[skillAbilityFields[skillIndex]]);
+                const deityAbility = getNumberIfValid(attributes[deityAbilityFields[i]]);
                 if (skillAbility !== deityAbility) {
                   update[deityAbilityFields[i]] = skillAbility;
                 }

--- a/ui/equipment/equipment.pug
+++ b/ui/equipment/equipment.pug
@@ -13,10 +13,10 @@
     div
       .attribute-name.larger.inline.bold.right.middle Wt. Pen.
       span.narrowish.center.bold.larger.value(name='attr_displayed_weight_penalty')
+      include ./speedTooltip.pug
     div
       .attribute-name.larger.inline.bold.right.middle Speed
       span.narrowish.center.bold.larger.value(name='attr_speed')
-      include ./speedTooltip.pug
   = '\n'
   .small-spacer
   .armor-table

--- a/ui/rollSection/rollSection.scss
+++ b/ui/rollSection/rollSection.scss
@@ -90,6 +90,7 @@ radio>span.checked {
   display: inline-flex;
   flex-direction: column;
   flex-grow: 1;
+  row-gap: 2px;
 }
 
 .roll-description-line {

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -98,21 +98,29 @@ const toggleSavePending = function () {
 };
 on('clicked:saveroll', toggleSavePending);
 
-const numericRollKeys = [
+/**
+ * Ordered list of roll keys (Do not reorganize)
+ */
+const roll_keys = [
+  'action_description',
   'action_feats',
   'action_EP',
   'action_SP',
+  'roll_skill',
   'roll_ability',
   'roll_mod1',
   'roll_mod2',
   'roll_mod3',
   'roll_advance_boost',
 ];
-const roll_keys = [
+const nonUpdateRollSectionKeys = new Set([
   'action_description',
   'roll_skill',
-  ...numericRollKeys,
-];
+  'roll_mod2',
+  'roll_mod3',
+]);
+
+const updateRollSectionNumericRollKeys = roll_keys.filter((key) => !nonUpdateRollSectionKeys.has(key));
 
 const saveRollState = function (key, roll_chosen) {
   getAttrs(roll_keys,
@@ -176,7 +184,7 @@ roll_choices.forEach(function (value) {
 
 function updateRollSectionContent({ skillName, description = '', abilityValue, advanceBoost, power }) {
   const baseNumericContent = {};
-  numericRollKeys.forEach((key) => {
+  updateRollSectionNumericRollKeys.forEach((key) => {
     baseNumericContent[key] = 0;
   });
 

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1630,7 +1630,7 @@ const updateWeightPenalties = function () {
     if (current_level === 6) { current_level = 100; }
     update['weight_penalty'] = -current_level;
     update['displayed_weight_penalty'] = (
-      current_level === 0 ? ' ' :
+      current_level === 0 ? '0' :
         current_level === 100 ? '-∞' :
           -current_level);
     setAttrs(update);

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -203,12 +203,12 @@ function updateRollSectionContent({ skillName, description = '', abilityValue, a
       'repeating_spell_spellEP'
     ], (attributes) => {
       const { ['repeating_skill_skillname']: skillName } = attributes;
-      const skillAbility = Number(attributes['repeating_skill_skillability'] ?? 0);
-      const advanceBoost = Number(attributes['repeating_skill_skillmodifier'] ?? 0);
+      const skillAbility = getNumberIfValid(attributes['repeating_skill_skillability']);
+      const advanceBoost = getNumberIfValid(attributes['repeating_skill_skillmodifier']);
       const deityName = attributes['repeating_skill_skill_deity_name'];
       let description = sectionName === 'repeating_divine' && deityName ? `Pray to ${deityName} ` : '';
       const spellPwr = isValueDefined(attributes['repeating_spell_spellEP']) ?
-        Number(attributes['repeating_spell_spellEP'] ?? 0) :
+        getNumberIfValid(attributes['repeating_spell_spellEP']) :
         undefined;
       console.log({skillName, skillAbility, advanceBoost});
       updateRollSectionContent({ skillName, description, abilityValue: skillAbility, advanceBoost, power: spellPwr });
@@ -294,8 +294,8 @@ GENERAL_UPDATE_ROLL_SECTION_OPTIONS.forEach((rollOption) => {
   on(`clicked:${actionId}`, () => {
     const { skillAbilityKey, advanceBoostKey } = attributes;
     getAttrs([skillAbilityKey, advanceBoostKey].filter(Boolean), (values) => {
-      const abilityValue = Number(values[skillAbilityKey] ?? 0);
-      const advanceBoost = Number(values[advanceBoostKey] ?? 0);
+      const abilityValue = getNumberIfValid(values[skillAbilityKey]);
+      const advanceBoost = getNumberIfValid(values[advanceBoostKey]);
 
       updateRollSectionContent({ skillName,abilityValue, advanceBoost });
     });
@@ -813,7 +813,7 @@ const updateAdvantagesCosts = function () {
             return {
               description_key: prefix + 'CPdescription',
               base_cost: advantageCosts[advantage],
-              count: Number(attributes[prefix + 'count'])
+              count: getNumberIfValid(attributes[prefix + 'count'])
             };
           });
         const extra_advantages = extra_ids.map(
@@ -821,7 +821,7 @@ const updateAdvantagesCosts = function () {
             const prefix = 'repeating_extraadvantage_' + extra_id + '_';
             return {
               description_key: prefix + 'extraadvantageCPdescription',
-              base_cost: Number(attributes[prefix + 'extraadvantageCP']),
+              base_cost: getNumberIfValid(attributes[prefix + 'extraadvantageCP']),
               count: 1
             };
           });
@@ -1249,8 +1249,8 @@ function updateDivineAttributes() {
             for (let skillIndex = 0; skillIndex < skillIds.length; ++skillIndex) {
               const skillName = attributes[skillNameFields[skillIndex]];
               if (skillName?.toLowerCase().trim().includes(deityName.toLowerCase().trim())) {
-                const skillAbility = Number(attributes[skillAbilityFields[skillIndex]] || 0);
-                const deityAbility = Number(attributes[deityAbilityFields[i]] || 0);
+                const skillAbility = getNumberIfValid(attributes[skillAbilityFields[skillIndex]]);
+                const deityAbility = getNumberIfValid(attributes[deityAbilityFields[i]]);
                 if (skillAbility !== deityAbility) {
                   update[deityAbilityFields[i]] = skillAbility;
                 }


### PR DESCRIPTION
> * For arcane spells, the if the PWR cost in the spell listing isn't a valid number, the PWR cost in the rolls section isn't being changed. It should be zeroed out, which is how it works for the divine section.

and

> When a copy button is clicked, the mods are getting copied to the boost in the roll section. I, at least, tend to use them to record long standing buffs, like from a high quality weapon, or the like. And, now with rolling happening in the top section, there is a place to put a boost, if desired. I think it might be better to copy the mods to the first mod field in the roll section.

Fixed here, along with mod2,mod3 - should we do mod2-mod3 or all 3?

and

> The ? button that brings up the weight penalty table should be next to the weight penalty, not to the right of speed, like it is now.
> When the weight penalty is 0, it shows as blank, which I found confusing. I think putting in a 0 would be clearer.


This is a small stacked change on top of #121