### PR TITLE
Recalculate the divine spell info when the order changes.

### DIFF
--- a/bin/main.html
+++ b/bin/main.html
@@ -2665,6 +2665,7 @@ function updateDivineAttributes() {
 
 on('change:repeating_divine:skilldisciplineinfo' +
   ' change:repeating_divine:skillname' +
+  ' change:_reporder:divine' +
   ' sheet:opened',
 updateDivineAttributes);
 

--- a/ui/scripts/inlineHtml/inlineScripts.js
+++ b/ui/scripts/inlineHtml/inlineScripts.js
@@ -1277,6 +1277,7 @@ function updateDivineAttributes() {
 
 on('change:repeating_divine:skilldisciplineinfo' +
   ' change:repeating_divine:skillname' +
+  ' change:_reporder:divine' +
   ' sheet:opened',
 updateDivineAttributes);
 


### PR DESCRIPTION
I noticed a bug when I added the deity's name to the bottom of a divine caster' spell list, made it "D", and the moved it to the top of the spells. When I then tried copying a spell to the roll section, it wasn't finding the prayer ability for the deity. It was because the reordering wasn't triggering the necessary recomputation.