### PR TITLE
Narrow frame support

### DIFF
--- a/bin/main.css
+++ b/bin/main.css
@@ -3518,7 +3518,7 @@ body.sheet-darkmode .character-sheet-page input.new-user-control:not([value=""])
   display: none;
 }
 .main-content .existing-user {
-  width: fit-content;
+  min-width: fit-content;
 }
 .main-content input.new-user-control[value=true] ~ div.new-user-creator, .main-content input.new-user-control:not([value=true]) ~ div.existing-user {
   display: block;

--- a/bin/main.css
+++ b/bin/main.css
@@ -639,6 +639,7 @@ radio > span.checked {
 
 .roll-description-line input[type=text] {
   flex: 1;
+  width: 150px;
 }
 
 .roll-description-line input + label {

--- a/bin/main.css
+++ b/bin/main.css
@@ -501,6 +501,7 @@ input[readonly] {
 /* ---------- Roll section ------------- */
 .roll-section {
   display: flex;
+  min-width: min-content;
   border: solid;
   border-color: hsl(213deg, 80%, 80%);
   border-width: 1px;

--- a/bin/main.css
+++ b/bin/main.css
@@ -385,7 +385,7 @@ body.sheet-darkmode .ui-dialog {
   flex-grow: 1;
 }
 
-.flexing input {
+input.flexing {
   width: 150px;
 }
 

--- a/bin/main.css
+++ b/bin/main.css
@@ -385,6 +385,10 @@ body.sheet-darkmode .ui-dialog {
   flex-grow: 1;
 }
 
+.flexing input {
+  width: 150px;
+}
+
 .no-shrink {
   flex-shrink: 0;
 }

--- a/bin/main.css
+++ b/bin/main.css
@@ -2925,12 +2925,14 @@ body.sheet-darkmode .spell-tabs {
 /* Avoid space between items in the row */
 .spells .spell-header-action-area {
   display: flex;
+  flex: 1;
   gap: 8px;
 }
-.spells .spell-header-action-area label, .spells .spell-header-action-area .label {
+.spells .spell-header-action-area .label {
+  flex: 1;
   color: #111;
 }
-body.sheet-darkmode .spells .spell-header-action-area label, body.sheet-darkmode .spells .spell-header-action-area .label {
+body.sheet-darkmode .spells .spell-header-action-area .label {
   color: #fff;
 }
 .spells .spell-header-action-area button.spellRoll {

--- a/bin/main.css
+++ b/bin/main.css
@@ -641,6 +641,10 @@ radio > span.checked {
   font-weight: normal;
 }
 
+.roll-description-line input[type=text] {
+  flex: 1;
+}
+
 .roll-description-line input + label {
   padding-left: 8px;
 }

--- a/bin/main.css
+++ b/bin/main.css
@@ -385,10 +385,6 @@ body.sheet-darkmode .ui-dialog {
   flex-grow: 1;
 }
 
-input.flexing {
-  width: 150px;
-}
-
 .no-shrink {
   flex-shrink: 0;
 }

--- a/bin/main.css
+++ b/bin/main.css
@@ -3517,6 +3517,9 @@ body.sheet-darkmode .character-sheet-page input.new-user-control:not([value=""])
 .main-content .new-user-creator, .main-content .existing-user {
   display: none;
 }
+.main-content .existing-user {
+  width: fit-content;
+}
 .main-content input.new-user-control[value=true] ~ div.new-user-creator, .main-content input.new-user-control:not([value=true]) ~ div.existing-user {
   display: block;
 }

--- a/bin/main.html
+++ b/bin/main.html
@@ -1019,18 +1019,18 @@
         <button class="tab" name="act_innate" type="action">Innate</button>
 
         &emsp; &emsp;
-        <div class="spell-header-action-area">
-          <div class="label wide larger">Spell Hit</div>
+        <div class="spell-header-action-area flexing">
+          <div class="label flexing larger">Spell Hit</div>
           <input name="attr_spell_hit" type="hidden" />
           <span class="center bold larger middle" name="attr_spell_hit"></span>
           <input class="skillbase" name="attr_spell_hit_modifier" type="number" />
           <button class="spellRoll updateRollSectionContent" name="act_updateRollSectionContent_spell_hit" type="action"></button>
-          <div class="label wide larger">Vigor</div>
+          <div class="label flexing larger">Vigor</div>
           <input name="attr_vigor" type="hidden" />
           <span class="center bold larger middle" name="attr_vigor"></span>
           <input class="skillbase" name="attr_vigor_modifier" type="number" />
           <button class="spellRoll updateRollSectionContent" name="act_updateRollSectionContent_vigor" type="action"></button>
-          <div class="label wide larger">Mental</div>
+          <div class="label flexing larger">Mental</div>
           <input name="attr_mental" type="hidden" />
           <span class="center bold larger middle" name="attr_mental"></span>
           <input class="skillbase" name="attr_mental_modifier" type="number" />

--- a/bin/main.html
+++ b/bin/main.html
@@ -1019,18 +1019,18 @@
         <button class="tab" name="act_innate" type="action">Innate</button>
 
         &emsp; &emsp;
-        <div class="spell-header-action-area flexing">
-          <div class="label flexing larger">Spell Hit</div>
+        <div class="spell-header-action-area">
+          <div class="label larger">Spell Hit</div>
           <input name="attr_spell_hit" type="hidden" />
           <span class="center bold larger middle" name="attr_spell_hit"></span>
           <input class="skillbase" name="attr_spell_hit_modifier" type="number" />
           <button class="spellRoll updateRollSectionContent" name="act_updateRollSectionContent_spell_hit" type="action"></button>
-          <div class="label flexing larger">Vigor</div>
+          <div class="label larger">Vigor</div>
           <input name="attr_vigor" type="hidden" />
           <span class="center bold larger middle" name="attr_vigor"></span>
           <input class="skillbase" name="attr_vigor_modifier" type="number" />
           <button class="spellRoll updateRollSectionContent" name="act_updateRollSectionContent_vigor" type="action"></button>
-          <div class="label flexing larger">Mental</div>
+          <div class="label larger">Mental</div>
           <input name="attr_mental" type="hidden" />
           <span class="center bold larger middle" name="attr_mental"></span>
           <input class="skillbase" name="attr_mental_modifier" type="number" />

--- a/bin/main.html
+++ b/bin/main.html
@@ -100,7 +100,7 @@
       <div class="roll-description-section">
         <div class="roll-description-line">
           <label class="action-area-text" for="attr_action_description">Description</label>
-          <input class="flexing" id="attr_action_description" name="attr_action_description" type="text" />
+          <input id="attr_action_description" name="attr_action_description" type="text" />
           <label class="action-area-text" for="attr_action_feats">Feat PWR</label>
           <input class="narrowish" id="attr_action_feats" name="attr_action_feats" type="number" value="0" />
           <label class="action-area-text" for="attr_action_EP">PWR</label>
@@ -110,7 +110,7 @@
         </div>
         <div class="roll-description-line">
           <label class="action-area-text" for="attr_roll_skill">Skill</label>
-          <input class="flexing" id="attr_roll_skill" name="attr_roll_skill" type="text" />
+          <input id="attr_roll_skill" name="attr_roll_skill" type="text" />
           <label class="action-area-text" for="attr_roll_ability">Ability</label>
           <input class="narrowish" id="attr_roll_ability" name="attr_roll_ability" type="number" value="0" />
           <label>Mods</label>

--- a/ui/global/global.scss
+++ b/ui/global/global.scss
@@ -100,6 +100,10 @@ button, input, optgroup, select, textarea {
   flex-grow: 1;
 }
 
+.flexing input {
+  width: 150px;
+}
+
 .no-shrink {
   flex-shrink: 0;
 }

--- a/ui/global/global.scss
+++ b/ui/global/global.scss
@@ -100,7 +100,7 @@ button, input, optgroup, select, textarea {
   flex-grow: 1;
 }
 
-.flexing input {
+input.flexing {
   width: 150px;
 }
 

--- a/ui/global/global.scss
+++ b/ui/global/global.scss
@@ -100,10 +100,6 @@ button, input, optgroup, select, textarea {
   flex-grow: 1;
 }
 
-input.flexing {
-  width: 150px;
-}
-
 .no-shrink {
   flex-shrink: 0;
 }

--- a/ui/main.scss
+++ b/ui/main.scss
@@ -22,6 +22,9 @@
   .new-user-creator, .existing-user {
     display: none;
   }
+  .existing-user {
+    width: fit-content;
+  }
   input.new-user-control {
     &[value="true"] ~ div.new-user-creator,
     &:not([value="true"]) ~ div.existing-user {

--- a/ui/main.scss
+++ b/ui/main.scss
@@ -23,7 +23,7 @@
     display: none;
   }
   .existing-user {
-    width: fit-content;
+    min-width: fit-content;
   }
   input.new-user-control {
     &[value="true"] ~ div.new-user-creator,

--- a/ui/rollSection/rollSection.pug
+++ b/ui/rollSection/rollSection.pug
@@ -31,7 +31,7 @@
   .roll-description-section
     .roll-description-line
       label.action-area-text(for='attr_action_description') Description
-      input#attr_action_description.flexing(name='attr_action_description' type='text')
+      input#attr_action_description(name='attr_action_description' type='text')
       label.action-area-text(for='attr_action_feats') Feat PWR
       input#attr_action_feats.narrowish(name='attr_action_feats' type='number' value='0')
       label.action-area-text(for='attr_action_EP') PWR
@@ -40,7 +40,7 @@
       input#attr_action_SP.narrowish(name='attr_action_SP' type='number' value='0')
     .roll-description-line
       label.action-area-text(for='attr_roll_skill') Skill
-      input#attr_roll_skill.flexing(name='attr_roll_skill' type='text')
+      input#attr_roll_skill(name='attr_roll_skill' type='text')
       label.action-area-text(for='attr_roll_ability') Ability
       input#attr_roll_ability.narrowish(name='attr_roll_ability' type='number' value='0')
       label Mods

--- a/ui/rollSection/rollSection.scss
+++ b/ui/rollSection/rollSection.scss
@@ -111,6 +111,10 @@ radio>span.checked {
   font-weight: normal;
 }
 
+.roll-description-line input[type="text"] {
+  flex: 1;
+}
+
 .roll-description-line input+label {
   padding-left: 8px;
 }

--- a/ui/rollSection/rollSection.scss
+++ b/ui/rollSection/rollSection.scss
@@ -113,6 +113,7 @@ radio>span.checked {
 
 .roll-description-line input[type="text"] {
   flex: 1;
+  width: 150px;
 }
 
 .roll-description-line input+label {

--- a/ui/rollSection/rollSection.scss
+++ b/ui/rollSection/rollSection.scss
@@ -2,6 +2,7 @@
 
 .roll-section {
   display: flex;
+  min-width: min-content;
   border: solid;
   @include theme-border-color(roll-section-border-color);
   border-width: 1px;

--- a/ui/spells/spells.pug
+++ b/ui/spells/spells.pug
@@ -19,18 +19,18 @@
     = '\n'
     = '\n'
     | &emsp; &emsp;
-    .spell-header-action-area.flexing
-      .label.flexing.larger Spell Hit
+    .spell-header-action-area
+      .label.larger Spell Hit
       input(name='attr_spell_hit' type='hidden')
       span.center.bold.larger.middle(name='attr_spell_hit')
       input.skillbase(name='attr_spell_hit_modifier' type='number')
       button.spellRoll.updateRollSectionContent(name='act_updateRollSectionContent_spell_hit' type='action')
-      .label.flexing.larger Vigor
+      .label.larger Vigor
       input(name='attr_vigor' type='hidden')
       span.center.bold.larger.middle(name='attr_vigor')
       input.skillbase(name='attr_vigor_modifier' type='number')
       button.spellRoll.updateRollSectionContent(name='act_updateRollSectionContent_vigor' type='action')
-      .label.flexing.larger Mental
+      .label.larger Mental
       input(name='attr_mental' type='hidden')
       span.center.bold.larger.middle(name='attr_mental')
       input.skillbase(name='attr_mental_modifier' type='number')

--- a/ui/spells/spells.pug
+++ b/ui/spells/spells.pug
@@ -19,18 +19,18 @@
     = '\n'
     = '\n'
     | &emsp; &emsp;
-    .spell-header-action-area
-      .label.wide.larger Spell Hit
+    .spell-header-action-area.flexing
+      .label.flexing.larger Spell Hit
       input(name='attr_spell_hit' type='hidden')
       span.center.bold.larger.middle(name='attr_spell_hit')
       input.skillbase(name='attr_spell_hit_modifier' type='number')
       button.spellRoll.updateRollSectionContent(name='act_updateRollSectionContent_spell_hit' type='action')
-      .label.wide.larger Vigor
+      .label.flexing.larger Vigor
       input(name='attr_vigor' type='hidden')
       span.center.bold.larger.middle(name='attr_vigor')
       input.skillbase(name='attr_vigor_modifier' type='number')
       button.spellRoll.updateRollSectionContent(name='act_updateRollSectionContent_vigor' type='action')
-      .label.wide.larger Mental
+      .label.flexing.larger Mental
       input(name='attr_mental' type='hidden')
       span.center.bold.larger.middle(name='attr_mental')
       input.skillbase(name='attr_mental_modifier' type='number')

--- a/ui/spells/spells.scss
+++ b/ui/spells/spells.scss
@@ -41,8 +41,10 @@ $notes-popover-width: 30px;
 .spells {
   .spell-header-action-area {
     display: flex;
+    flex: 1;
     gap: 8px;
-    label, .label {
+    .label {
+      flex: 1;
       @include theme-color(primary-color);
     }
     button.spellRoll {


### PR DESCRIPTION
In the other campaign, one of the players was using a phone. The roll button was disappearing off the right of their screen. 

Make the roll box cause the whole sheet to scroll horizontally if the frame isn't wide enough, rather than have its content disappear off the frame.